### PR TITLE
Unconditionally enable nrf52-hal-common features

### DIFF
--- a/nrf52832-hal/Cargo.toml
+++ b/nrf52832-hal/Cargo.toml
@@ -18,6 +18,7 @@ void = { version = "1", default-features = false }
 
 [dependencies.nrf52-hal-common]
 path = "../nrf52-hal-common"
+features = ["52832"]
 
 [dependencies.nrf52]
 version = "0.4.0"
@@ -32,6 +33,6 @@ version = "0.2.1"
 
 [features]
 doc = []
-rt = ["nrf52/rt", "nrf52-hal-common/52832"]
+rt = ["nrf52/rt"]
 default = ["rt"]
 

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -23,6 +23,7 @@ version = "0.2.2"
 
 [dependencies.nrf52-hal-common]
 path = "../nrf52-hal-common"
+features = ["52840"]
 
 [dependencies.embedded-hal]
 features = ["unproven"]
@@ -34,5 +35,5 @@ version = "1.0.2"
 
 [features]
 default = ["rt"]
-rt = ["nrf52840/rt", "nrf52-hal-common/52840"]
+rt = ["nrf52840/rt"]
 


### PR DESCRIPTION
The features that define which target is chosen is always required,
independently of whether the `rt` feature is enabled.