### PR TITLE
Clear counter value when starting timer

### DIFF
--- a/nrf52-hal-common/src/timer.rs
+++ b/nrf52-hal-common/src/timer.rs
@@ -83,6 +83,11 @@ impl<T> Timer<T> where T: TimerExt {
             unsafe { w.cc().bits(cycles) }
         );
 
+        // Clear the counter value
+        self.0.tasks_clear.write(|w|
+            unsafe { w.bits(1) }
+        );
+
         // Start the timer
         self.0.tasks_start.write(|w|
             unsafe { w.bits(1) }


### PR DESCRIPTION
Previously, calling the `start` method while the timer was already
running had no effect, and the `cycles` argument was ignored. Now it
effectively restarts the timer.