### PR TITLE
Add interface to RNG peripheral

### DIFF
--- a/nrf52-hal-common/src/lib.rs
+++ b/nrf52-hal-common/src/lib.rs
@@ -16,6 +16,7 @@ pub mod delay;
 pub mod spim;
 pub mod gpio;
 pub mod clocks;
+pub mod rng;
 pub mod time;
 pub mod timer;
 
@@ -24,6 +25,7 @@ pub mod prelude {
 
     pub use clocks::ClocksExt;
     pub use gpio::GpioExt;
+    pub use rng::RngExt;
     pub use spim::SpimExt;
     pub use time::U32Ext;
     pub use timer::TimerExt;

--- a/nrf52-hal-common/src/rng.rs
+++ b/nrf52-hal-common/src/rng.rs
@@ -1,0 +1,86 @@
+//! HAL interface to the RNG peripheral
+//!
+//! See nRF52832 product specification, chapter 26.
+
+
+use core::ops::Deref;
+
+use target::{
+    rng,
+    RNG,
+};
+
+
+pub trait RngExt : Deref<Target=rng::RegisterBlock> + Sized {
+    fn constrain(self) -> Rng;
+}
+
+impl RngExt for RNG {
+    fn constrain(self) -> Rng {
+        Rng(self)
+    }
+}
+
+
+/// Interface to the RNG peripheral
+///
+/// Right now, this is very basic, only providing blocking interfaces.
+pub struct Rng(RNG);
+
+impl Rng {
+    /// Fill the provided buffer with random bytes
+    ///
+    /// Will block until the buffer is full.
+    pub fn random(&mut self, buf: &mut [u8]) {
+        self.0.tasks_start.write(|w| unsafe { w.bits(1) });
+
+        for b in buf {
+            // Wait for random byte to become ready, reset the flag once it is
+            while self.0.events_valrdy.read().bits() == 0 {}
+            self.0.events_valrdy.write(|w| unsafe { w.bits(0) });
+
+            *b = self.0.value.read().value().bits();
+        }
+
+        self.0.tasks_stop.write(|w| unsafe { w.bits(1) });
+    }
+
+    /// Return a random `u8`
+    pub fn random_u8(&mut self) -> u8 {
+        let mut buf = [0; 1];
+        self.random(&mut buf);
+        buf[0]
+    }
+
+    /// Return a random `u16`
+    pub fn random_u16(&mut self) -> u16 {
+        let mut buf = [0; 2];
+        self.random(&mut buf);
+        buf[0] as u16 |
+            (buf[1] as u16) << 8
+    }
+
+    /// Return a random `u32`
+    pub fn random_u32(&mut self) -> u32 {
+        let mut buf = [0; 4];
+        self.random(&mut buf);
+        buf[0] as u32 |
+            (buf[1] as u32) <<  8 |
+            (buf[2] as u32) << 16 |
+            (buf[3] as u32) << 24
+    }
+
+    /// Return a random `u64`
+    pub fn random_u64(&mut self) -> u64 {
+        let mut buf = [0; 8];
+        self.random(&mut buf);
+        buf[0] as u64 |
+            (buf[1] as u64) <<  8 |
+            (buf[2] as u64) << 16 |
+            (buf[3] as u64) << 24 |
+            (buf[4] as u64) << 32 |
+            (buf[5] as u64) << 40 |
+            (buf[6] as u64) << 48 |
+            (buf[7] as u64) << 56
+    }
+}


### PR DESCRIPTION
I've only tested this on an nRF52832, but since it compiles, I assume it'll work on nRF52840, too.