### PR TITLE
Changes for the next release, detailed list of changes:

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,10 +1,9 @@
 [target.thumbv7em-none-eabihf]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
-  "-C", "link-arg=-Tlink.x",
-  "-C", "linker=arm-none-eabi-ld",
-  "-Z", "linker-flavor=ld",
-  "-Z", "thinlto=no",
+    "-C", "linker=arm-none-eabi-gcc",
+    "-C", "link-arg=-Wl,-Tlink.x",
+    "-C", "link-arg=-nostartfiles",
 ]
 
 [build]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - nightly
+  - stable
 cache: cargo
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: rust
 rust:
   - stable
+  - beta
+  - nightly
 cache: cargo
 addons:
   apt:

--- a/boards/adafruit_nrf52pro/Cargo.toml
+++ b/boards/adafruit_nrf52pro/Cargo.toml
@@ -6,13 +6,14 @@ keywords = ["arm", "cortex-m", "nrf52", "hal"]
 license = "MIT OR Apache-2.0"
 name = "adafruit_nrf52pro"
 repository = "https://github.com/nrf-rs/nrf52-hal"
-version = "0.0.1"
+version = "0.6.0-beta.1"
+edition = "2018"
 
 [dependencies]
 nrf52832-hal = { path = "../../nrf52832-hal" }
 
 [dev-dependencies]
-cortex-m-rt = "~0.5"
+cortex-m-rt = "0.6.5"
 cortex-m-semihosting = "~0.3"
 panic-semihosting = "~0.3"
 nb = "~0.1"

--- a/boards/adafruit_nrf52pro/Cargo.toml
+++ b/boards/adafruit_nrf52pro/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["embedded", "hardware-support", "no-std"]
 description = "Support for Adafruit nRF52 Feathers"
 keywords = ["arm", "cortex-m", "nrf52", "hal"]
 license = "MIT OR Apache-2.0"
-name = "adafruit_nrf52pro"
+name = "adafruit-nrf52pro-bsc"
 repository = "https://github.com/nrf-rs/nrf52-hal"
 version = "0.6.0-beta.1"
 edition = "2018"
@@ -15,7 +15,7 @@ nrf52832-hal = { path = "../../nrf52832-hal" }
 [dev-dependencies]
 cortex-m-rt = "0.6.5"
 cortex-m-semihosting = "~0.3"
-panic-semihosting = "~0.3"
+panic-semihosting = "~0.5"
 nb = "~0.1"
 
 [features]

--- a/boards/adafruit_nrf52pro/Cargo.toml
+++ b/boards/adafruit_nrf52pro/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["arm", "cortex-m", "nrf52", "hal"]
 license = "MIT OR Apache-2.0"
 name = "adafruit-nrf52pro-bsc"
 repository = "https://github.com/nrf-rs/nrf52-hal"
-version = "0.6.0-beta.1"
+version = "0.6.0"
 edition = "2018"
 
 [dependencies]

--- a/boards/adafruit_nrf52pro/examples/blinky.rs
+++ b/boards/adafruit_nrf52pro/examples/blinky.rs
@@ -1,24 +1,22 @@
 #![no_main]
 #![no_std]
 
-#[macro_use]
-extern crate cortex_m_rt;
-#[macro_use]
-extern crate nb;
+use cortex_m_rt::entry;
+use nb::block;
 
-extern crate adafruit_nrf52pro;
-extern crate panic_semihosting;
+#[allow(unused_imports)]
+use panic_semihosting;
 
-use adafruit_nrf52pro::hal::{
+use adafruit_nrf52pro_bsc::hal::{
     prelude::*,
     gpio::Level,
     timer::Timer,
 };
-use adafruit_nrf52pro::nrf52::{Peripherals};
-use adafruit_nrf52pro::Pins;
+use adafruit_nrf52pro_bsc::nrf52832_pac::{Peripherals};
+use adafruit_nrf52pro_bsc::Pins;
 
-entry!(main);
 
+#[entry]
 fn main() -> ! {
     let p = Peripherals::take().unwrap();
     let pins = Pins::new(p.P0.split());

--- a/boards/adafruit_nrf52pro/src/lib.rs
+++ b/boards/adafruit_nrf52pro/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
-pub extern crate nrf52832_hal as hal;
+pub use nrf52832_hal as hal;
 use crate::hal::gpio::{p0, Floating, Input};
-pub use crate::hal::nrf52;
+pub use crate::hal::nrf52832_pac;
 
 /// Maps the pins to the names printed on the device
 pub struct Pins {

--- a/boards/adafruit_nrf52pro/src/lib.rs
+++ b/boards/adafruit_nrf52pro/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 pub extern crate nrf52832_hal as hal;
-use hal::gpio::{p0, Floating, Input};
-pub use hal::nrf52;
+use crate::hal::gpio::{p0, Floating, Input};
+pub use crate::hal::nrf52;
 
 /// Maps the pins to the names printed on the device
 pub struct Pins {

--- a/nrf52-hal-common/Cargo.toml
+++ b/nrf52-hal-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52-hal-common"
-version = "0.6.0-beta.1"
+version = "0.6.0-beta.2"
 description = "Common HAL for the nRF52 family of microcontrollers.  More specific HAL crates also exist."
 
 repository = "https://github.com/nrf-rs/nrf52-hal"

--- a/nrf52-hal-common/Cargo.toml
+++ b/nrf52-hal-common/Cargo.toml
@@ -6,7 +6,7 @@ description = "Common HAL for the nRF52 family of microcontrollers.  More specif
 repository = "https://github.com/nrf-rs/nrf52-hal"
 authors = [
     "James Munns <james@onevariable.com>",
-    "Hanno Braun <hanno@braun-robotics.com",
+    "Hanno Braun <hanno@braun-robotics.com>",
     "John Scarrott <johnps@outlook.com>",
     "Wez Furlong <wez@wezfurlong.org>",
 ]

--- a/nrf52-hal-common/Cargo.toml
+++ b/nrf52-hal-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52-hal-common"
-version = "0.6.0-beta.3"
+version = "0.6.0"
 description = "Common HAL for the nRF52 family of microcontrollers.  More specific HAL crates also exist."
 
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -30,11 +30,11 @@ version = "0.2.2"
 
 [dependencies.nrf52832-pac]
 optional = true
-version = "=0.6.0-beta.2"
+version = "=0.6.0"
 
 [dependencies.nrf52840-pac]
 optional = true
-version = "=0.6.0-beta.2"
+version = "=0.6.0"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52-hal-common/Cargo.toml
+++ b/nrf52-hal-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52-hal-common"
-version = "0.6.0-beta.2"
+version = "0.6.0-beta.3"
 description = "Common HAL for the nRF52 family of microcontrollers.  More specific HAL crates also exist."
 
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -30,11 +30,11 @@ version = "0.2.2"
 
 [dependencies.nrf52832-pac]
 optional = true
-version = "=0.6.0-beta.1"
+version = "=0.6.0-beta.2"
 
 [dependencies.nrf52840-pac]
 optional = true
-version = "=0.6.0-beta.1"
+version = "=0.6.0-beta.2"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52-hal-common/Cargo.toml
+++ b/nrf52-hal-common/Cargo.toml
@@ -42,7 +42,7 @@ version = "0.2.1"
 
 [features]
 doc = []
-default = []
+default = ["52832"]
 52832 = ["nrf52832-pac"]
 52840 = ["nrf52840-pac"]
 

--- a/nrf52-hal-common/Cargo.toml
+++ b/nrf52-hal-common/Cargo.toml
@@ -30,11 +30,11 @@ version = "0.2.2"
 
 [dependencies.nrf52832-pac]
 optional = true
-version = "=0.6.0"
+version = "0.6.0"
 
 [dependencies.nrf52840-pac]
 optional = true
-version = "=0.6.0"
+version = "0.6.0"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52-hal-common/Cargo.toml
+++ b/nrf52-hal-common/Cargo.toml
@@ -1,41 +1,48 @@
 [package]
-authors = [
-    "James Munns <james.munns@gmail.com>",
-    "Hanno Braun <hanno@braun-robotics.com",
-    "Wez Furlong <wez@wezfurlong.org",
-]
-categories = ["embedded", "hardware-support", "no-std"]
+name = "nrf52-hal-common"
+version = "0.6.0-beta.1"
 description = "Common HAL for the nRF52 family of microcontrollers.  More specific HAL crates also exist."
+
+repository = "https://github.com/nrf-rs/nrf52-hal"
+authors = [
+    "James Munns <james@onevariable.com>",
+    "Hanno Braun <hanno@braun-robotics.com",
+    "John Scarrott <johnps@outlook.com>",
+    "Wez Furlong <wez@wezfurlong.org>",
+]
+
+categories = ["embedded", "hardware-support", "no-std"]
 keywords = ["arm", "cortex-m", "nrf52", "hal"]
 license = "MIT OR Apache-2.0"
-name = "nrf52-hal-common"
-repository = "https://github.com/nrf-rs/nrf52-hal"
-version = "0.0.1"
+edition = "2018"
 
 [dependencies]
-cortex-m = "0.5.4"
+cortex-m = "0.5.8"
 nb = "0.1.1"
-void = { version = "1", default-features = false }
+
+[dependencies.void]
+default-features = false
+version = "1.0.2"
 
 [dependencies.cast]
 default-features = false
 version = "0.2.2"
 
+[dependencies.nrf52832-pac]
+optional = true
+version = "=0.6.0-beta.1"
+
+[dependencies.nrf52840-pac]
+optional = true
+version = "=0.6.0-beta.1"
+
 [dependencies.embedded-hal]
 features = ["unproven"]
 version = "0.2.1"
 
-[dependencies.nrf52]
-optional = true
-version = "~0.4"
-
-[dependencies.nrf52840]
-optional = true
-version = "~0.2"
-
 [features]
 doc = []
 default = []
-52832 = ["nrf52"]
-52840 = ["nrf52840"]
+52832 = ["nrf52832-pac"]
+52840 = ["nrf52840-pac"]
 

--- a/nrf52-hal-common/src/clocks.rs
+++ b/nrf52-hal-common/src/clocks.rs
@@ -1,5 +1,5 @@
-use target::CLOCK;
-use time::{Hertz, U32Ext};
+use crate::target::CLOCK;
+use crate::time::{Hertz, U32Ext};
 
 pub trait ClocksExt {
     fn constrain(self) -> ClocksCfg;

--- a/nrf52-hal-common/src/delay.rs
+++ b/nrf52-hal-common/src/delay.rs
@@ -3,8 +3,8 @@ use cast::u32;
 use cortex_m::peripheral::SYST;
 use cortex_m::peripheral::syst::SystClkSource;
 
-use hal::blocking::delay::{DelayMs, DelayUs};
-use clocks::Clocks;
+use crate::hal::blocking::delay::{DelayMs, DelayUs};
+use crate::clocks::Clocks;
 
 /// System timer (SysTick) as a delay provider
 pub struct Delay {

--- a/nrf52-hal-common/src/gpio.rs
+++ b/nrf52-hal-common/src/gpio.rs
@@ -73,13 +73,13 @@ macro_rules! gpio {
                 PhantomData,
             };
 
-            use target;
-            use target::$PX;
-            use target::$pxsvd::{
+            use crate::target;
+            use crate::target::$PX;
+            use crate::target::$pxsvd::{
                 pin_cnf,
                 PIN_CNF,
             };
-            use hal::digital::{OutputPin, StatefulOutputPin, InputPin};
+            use crate::hal::digital::{OutputPin, StatefulOutputPin, InputPin};
 
             // ===============================================================
             // Implement Generic Pins for this port, which allows you to use

--- a/nrf52-hal-common/src/lib.rs
+++ b/nrf52-hal-common/src/lib.rs
@@ -1,16 +1,12 @@
 #![no_std]
 
-extern crate cast;
-extern crate cortex_m;
-extern crate embedded_hal as hal;
-extern crate nb;
-extern crate void;
+use embedded_hal as hal;
 
 #[cfg(feature = "52832")]
-pub extern crate nrf52 as target;
+pub use nrf52832_pac as target;
 
 #[cfg(feature = "52840")]
-pub extern crate nrf52840 as target;
+pub use nrf52840_pac as target;
 
 pub mod delay;
 pub mod spim;
@@ -23,22 +19,22 @@ pub mod twim;
 pub mod uarte;
 
 pub mod prelude {
-    pub use hal::prelude::*;
+    pub use crate::hal::prelude::*;
 
-    pub use clocks::ClocksExt;
-    pub use gpio::GpioExt;
-    pub use rng::RngExt;
-    pub use spim::SpimExt;
-    pub use time::U32Ext;
-    pub use timer::TimerExt;
-    pub use twim::TwimExt;
-    pub use uarte::UarteExt;
+    pub use crate::clocks::ClocksExt;
+    pub use crate::gpio::GpioExt;
+    pub use crate::rng::RngExt;
+    pub use crate::spim::SpimExt;
+    pub use crate::time::U32Ext;
+    pub use crate::timer::TimerExt;
+    pub use crate::twim::TwimExt;
+    pub use crate::uarte::UarteExt;
 }
 
 
-pub use clocks::Clocks;
-pub use delay::Delay;
-pub use spim::Spim;
-pub use timer::Timer;
-pub use twim::Twim;
-pub use uarte::Uarte;
+pub use crate::clocks::Clocks;
+pub use crate::delay::Delay;
+pub use crate::spim::Spim;
+pub use crate::timer::Timer;
+pub use crate::twim::Twim;
+pub use crate::uarte::Uarte;

--- a/nrf52-hal-common/src/rng.rs
+++ b/nrf52-hal-common/src/rng.rs
@@ -4,6 +4,7 @@
 
 
 use core::ops::Deref;
+use core::sync::atomic::{compiler_fence, Ordering::AcqRel};
 
 use crate::target::{
     rng,
@@ -41,6 +42,10 @@ impl Rng {
 
             *b = self.0.value.read().value().bits();
         }
+
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account DMA
+        compiler_fence(AcqRel);
 
         self.0.tasks_stop.write(|w| unsafe { w.bits(1) });
     }

--- a/nrf52-hal-common/src/rng.rs
+++ b/nrf52-hal-common/src/rng.rs
@@ -4,7 +4,6 @@
 
 
 use core::ops::Deref;
-use core::sync::atomic::{compiler_fence, Ordering::AcqRel};
 
 use crate::target::{
     rng,
@@ -42,10 +41,6 @@ impl Rng {
 
             *b = self.0.value.read().value().bits();
         }
-
-        // Conservative compiler fence to prevent optimizations that do not
-        // take in to account DMA
-        compiler_fence(AcqRel);
 
         self.0.tasks_stop.write(|w| unsafe { w.bits(1) });
     }

--- a/nrf52-hal-common/src/rng.rs
+++ b/nrf52-hal-common/src/rng.rs
@@ -5,7 +5,7 @@
 
 use core::ops::Deref;
 
-use target::{
+use crate::target::{
     rng,
     RNG,
 };

--- a/nrf52-hal-common/src/spim.rs
+++ b/nrf52-hal-common/src/spim.rs
@@ -128,6 +128,11 @@ impl<T> Spim<T> where T: SpimExt {
         // Pull chip select pin high, which is the inactive state
         chip_select.set_high();
 
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account actions by DMA. The fence has been placed here,
+        // before any DMA action has started
+        compiler_fence(SeqCst);
+
         // Set up the DMA write
         self.0.txd.ptr.write(|w|
             // We're giving the register a pointer to the stack. Since we're
@@ -217,6 +222,11 @@ impl<T> Spim<T> where T: SpimExt {
 
         // Pull chip select pin high, which is the inactive state
         chip_select.set_high();
+
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account actions by DMA. The fence has been placed here,
+        // before any DMA action has started
+        compiler_fence(SeqCst);
 
         // Set up the DMA write
         self.0.txd.ptr.write(|w|

--- a/nrf52-hal-common/src/spim.rs
+++ b/nrf52-hal-common/src/spim.rs
@@ -2,6 +2,7 @@
 //!
 //! See product specification, chapter 31.
 use core::ops::Deref;
+use core::sync::atomic::{compiler_fence, Ordering::AcqRel};
 
 use crate::target::{
     spim0,
@@ -188,6 +189,10 @@ impl<T> Spim<T> where T: SpimExt {
             return Err(Error::Receive);
         }
 
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account DMA
+        compiler_fence(AcqRel);
+
         Ok(())
     }
 
@@ -258,6 +263,10 @@ impl<T> Spim<T> where T: SpimExt {
         if self.0.txd.amount.read().bits() != tx_buffer.len() as u32 {
             return Err(Error::Transmit);
         }
+
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account DMA
+        compiler_fence(AcqRel);
 
         Ok(())
     }

--- a/nrf52-hal-common/src/spim.rs
+++ b/nrf52-hal-common/src/spim.rs
@@ -3,15 +3,15 @@
 //! See product specification, chapter 31.
 use core::ops::Deref;
 
-use target::{
+use crate::target::{
     spim0,
     SPIM0,
     SPIM1,
     SPIM2,
 };
 
-use prelude::*;
-use gpio::{
+use crate::prelude::*;
+use crate::gpio::{
     p0::P0_Pin,
     Floating,
     Input,

--- a/nrf52-hal-common/src/timer.rs
+++ b/nrf52-hal-common/src/timer.rs
@@ -6,7 +6,7 @@
 use core::ops::Deref;
 
 use nb;
-use target::{
+use crate::target::{
     timer0,
     TIMER0,
     TIMER1,

--- a/nrf52-hal-common/src/twim.rs
+++ b/nrf52-hal-common/src/twim.rs
@@ -118,6 +118,11 @@ impl<T> Twim<T> where T: TwimExt {
             return Err(Error::BufferTooLong);
         }
 
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account actions by DMA. The fence has been placed here,
+        // before any DMA action has started
+        compiler_fence(SeqCst);
+
         self.0.address.write(|w| unsafe { w.address().bits(address) });
 
         // Set up the DMA write
@@ -184,6 +189,11 @@ impl<T> Twim<T> where T: TwimExt {
         if buffer.len() > u8::max_value() as usize {
             return Err(Error::BufferTooLong);
         }
+
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account actions by DMA. The fence has been placed here,
+        // before any DMA action has started
+        compiler_fence(SeqCst);
 
         self.0.address.write(|w| unsafe { w.address().bits(address) });
 
@@ -262,6 +272,11 @@ impl<T> Twim<T> where T: TwimExt {
         if rd_buffer.len() > u8::max_value() as usize {
             return Err(Error::BufferTooLong);
         }
+
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account actions by DMA. The fence has been placed here,
+        // before any DMA action has started
+        compiler_fence(SeqCst);
 
         self.0.address.write(|w| unsafe { w.address().bits(address) });
 

--- a/nrf52-hal-common/src/twim.rs
+++ b/nrf52-hal-common/src/twim.rs
@@ -8,21 +8,21 @@
 
 use core::ops::Deref;
 
-use target::{
+use crate::target::{
     twim0,
     P0,
     TWIM0,
     TWIM1,
 };
 
-use gpio::{
+use crate::gpio::{
     p0::P0_Pin,
     Floating,
     Input,
 };
 
 
-pub use target::twim0::frequency::FREQUENCYW as Frequency;
+pub use crate::target::twim0::frequency::FREQUENCYW as Frequency;
 
 
 pub trait TwimExt: Deref<Target=twim0::RegisterBlock> + Sized {
@@ -99,7 +99,7 @@ impl<T> Twim<T> where T: TwimExt {
 
         // Configure frequency
         twim.frequency.write(|w| w.frequency().variant(frequency));
-        
+
 
         Twim(twim)
     }

--- a/nrf52-hal-common/src/twim.rs
+++ b/nrf52-hal-common/src/twim.rs
@@ -240,6 +240,110 @@ impl<T> Twim<T> where T: TwimExt {
         Ok(())
     }
 
+    /// Write data to an I2C slave, then read data from the slave without
+    /// triggering a stop condition between the two
+    ///
+    /// The buffer must have a length of at most 255 bytes.
+    pub fn write_then_read(&mut self,
+        address: u8,
+        wr_buffer:  &[u8],
+        rd_buffer: &mut [u8],
+    )
+        -> Result<(), Error>
+    {
+        // This is overly restrictive. See:
+        // https://github.com/nrf-rs/nrf52-hal/issues/17
+        if wr_buffer.len() > u8::max_value() as usize {
+            return Err(Error::BufferTooLong);
+        }
+
+        if rd_buffer.len() > u8::max_value() as usize {
+            return Err(Error::BufferTooLong);
+        }
+
+        self.0.address.write(|w| unsafe { w.address().bits(address) });
+
+        // Set up the DMA write
+        self.0.txd.ptr.write(|w|
+            // We're giving the register a pointer to the stack. Since we're
+            // waiting for the I2C transaction to end before this stack pointer
+            // becomes invalid, there's nothing wrong here.
+            //
+            // The PTR field is a full 32 bits wide and accepts the full range
+            // of values.
+            unsafe { w.ptr().bits(wr_buffer.as_ptr() as u32) }
+        );
+        self.0.txd.maxcnt.write(|w|
+            // We're giving it the length of the buffer, so no danger of
+            // accessing invalid memory. We have verified that the length of the
+            // buffer fits in an `u8`, so the cast to `u8` is also fine.
+            //
+            // The MAXCNT field is 8 bits wide and accepts the full range of
+            // values.
+            unsafe { w.maxcnt().bits(wr_buffer.len() as _) }
+        );
+
+        // Set up the DMA read
+        self.0.rxd.ptr.write(|w|
+            // We're giving the register a pointer to the stack. Since we're
+            // waiting for the I2C transaction to end before this stack pointer
+            // becomes invalid, there's nothing wrong here.
+            //
+            // The PTR field is a full 32 bits wide and accepts the full range
+            // of values.
+            unsafe { w.ptr().bits(rd_buffer.as_mut_ptr() as u32) }
+        );
+        self.0.rxd.maxcnt.write(|w|
+            // We're giving it the length of the buffer, so no danger of
+            // accessing invalid memory. We have verified that the length of the
+            // buffer fits in an `u8`, so the cast to the type of maxcnt
+            // is also fine.
+            //
+            // Note that that nrf52840 maxcnt is a wider
+            // type than a u8, so we use a `_` cast rather than a `u8` cast.
+            // The MAXCNT field is thus at least 8 bits wide and accepts the
+            // full range of values that fit in a `u8`.
+            unsafe { w.maxcnt().bits(rd_buffer.len() as _) }
+        );
+
+        // Immediately start RX after TX, then stop
+        self.0.shorts.modify(|_r, w|
+            w.lasttx_startrx().enabled()
+             .lastrx_stop().enabled()
+        );
+
+        // Start write operation
+        self.0.tasks_starttx.write(|w|
+            // `1` is a valid value to write to task registers.
+            unsafe { w.bits(1) }
+        );
+
+        // Wait until total operation has ended
+        while self.0.events_stopped.read().bits() == 0 {}
+
+        self.0.events_lasttx.write(|w| w); // reset event
+        self.0.events_lastrx.write(|w| w); // reset event
+        self.0.events_stopped.write(|w| w); // reset event
+        self.0.shorts.write(|w| w);
+
+        let bad_write = self.0.txd.amount.read().bits() != wr_buffer.len() as u32;
+        let bad_read  = self.0.rxd.amount.read().bits() != rd_buffer.len() as u32;
+
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account DMA
+        compiler_fence(AcqRel);
+
+        if bad_write {
+            return Err(Error::Transmit);
+        }
+
+        if bad_read {
+            return Err(Error::Receive);
+        }
+
+        Ok(())
+    }
+
     /// Return the raw interface to the underlying TWIM peripheral
     pub fn free(self) -> T {
         self.0

--- a/nrf52-hal-common/src/twim.rs
+++ b/nrf52-hal-common/src/twim.rs
@@ -4,9 +4,8 @@
 //!
 //! - nrf52832: Section 33
 //! - nrf52840: Section 6.31
-
-
 use core::ops::Deref;
+use core::sync::atomic::{compiler_fence, Ordering::AcqRel};
 
 use crate::target::{
     twim0,
@@ -165,6 +164,10 @@ impl<T> Twim<T> where T: TwimExt {
             return Err(Error::Transmit);
         }
 
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account DMA
+        compiler_fence(AcqRel);
+
         Ok(())
     }
 
@@ -229,6 +232,10 @@ impl<T> Twim<T> where T: TwimExt {
         if self.0.rxd.amount.read().bits() != buffer.len() as u32 {
             return Err(Error::Receive);
         }
+
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account DMA
+        compiler_fence(AcqRel);
 
         Ok(())
     }

--- a/nrf52-hal-common/src/uarte.rs
+++ b/nrf52-hal-common/src/uarte.rs
@@ -115,6 +115,11 @@ impl<T> Uarte<T> where T: UarteExt {
             return Err(Error::TxBufferTooLong);
         }
 
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account actions by DMA. The fence has been placed here,
+        // before any DMA action has started
+        compiler_fence(SeqCst);
+
         // Set up the DMA write
         self.0.txd.ptr.write(|w|
             // We're giving the register a pointer to the stack. Since we're

--- a/nrf52-hal-common/src/uarte.rs
+++ b/nrf52-hal-common/src/uarte.rs
@@ -5,7 +5,7 @@
 //! - nrf52832: Section 35
 //! - nrf52840: Section 6.34
 use core::ops::Deref;
-use core::sync::atomic::{compiler_fence, Ordering::AcqRel};
+use core::sync::atomic::{compiler_fence, Ordering::SeqCst};
 
 use crate::target::{
     uarte0,
@@ -146,8 +146,9 @@ impl<T> Uarte<T> where T: UarteExt {
         self.0.events_endtx.write(|w| w);
 
         // Conservative compiler fence to prevent optimizations that do not
-        // take in to account DMA
-        compiler_fence(AcqRel);
+        // take in to account actions by DMA. The fence has been placed here,
+        // after all possible DMA actions have completed
+        compiler_fence(SeqCst);
 
         if self.0.txd.amount.read().bits() != tx_buffer.len() as u32 {
             return Err(Error::Transmit);

--- a/nrf52-hal-common/src/uarte.rs
+++ b/nrf52-hal-common/src/uarte.rs
@@ -4,8 +4,8 @@
 //!
 //! - nrf52832: Section 35
 //! - nrf52840: Section 6.34
-
 use core::ops::Deref;
+use core::sync::atomic::{compiler_fence, Ordering::AcqRel};
 
 use crate::target::{
     uarte0,
@@ -148,6 +148,10 @@ impl<T> Uarte<T> where T: UarteExt {
         if self.0.txd.amount.read().bits() != tx_buffer.len() as u32 {
             return Err(Error::Transmit);
         }
+
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account DMA
+        compiler_fence(AcqRel);
 
         Ok(())
     }

--- a/nrf52-hal-common/src/uarte.rs
+++ b/nrf52-hal-common/src/uarte.rs
@@ -7,20 +7,20 @@
 
 use core::ops::Deref;
 
-use target::{
+use crate::target::{
     uarte0,
     UARTE0,
 };
 
-use prelude::*;
-use gpio::{
+use crate::prelude::*;
+use crate::gpio::{
     p0::P0_Pin,
     Output,
     PushPull,
 };
 
 // Re-export SVD variants to allow user to directly set values
-pub use target::uarte0::{
+pub use crate::target::uarte0::{
     baudrate::BAUDRATEW as Baudrate,
     config::PARITYW as Parity,
 };

--- a/nrf52-hal-common/src/uarte.rs
+++ b/nrf52-hal-common/src/uarte.rs
@@ -145,13 +145,13 @@ impl<T> Uarte<T> where T: UarteExt {
         // Reset the event, otherwise it will always read `1` from now on.
         self.0.events_endtx.write(|w| w);
 
-        if self.0.txd.amount.read().bits() != tx_buffer.len() as u32 {
-            return Err(Error::Transmit);
-        }
-
         // Conservative compiler fence to prevent optimizations that do not
         // take in to account DMA
         compiler_fence(AcqRel);
+
+        if self.0.txd.amount.read().bits() != tx_buffer.len() as u32 {
+            return Err(Error::Transmit);
+        }
 
         Ok(())
     }

--- a/nrf52832-hal/Cargo.toml
+++ b/nrf52832-hal/Cargo.toml
@@ -6,7 +6,7 @@ description = "HAL for nRF52832 microcontrollers"
 repository = "https://github.com/nrf-rs/nrf52-hal"
 authors = [
     "James Munns <james@onevariable.com>",
-    "Hanno Braun <hanno@braun-robotics.com"
+    "Hanno Braun <hanno@braun-robotics.com>"
 ]
 
 categories = ["embedded", "hardware-support", "no-std"]
@@ -29,6 +29,7 @@ version = "0.2.2"
 
 [dependencies.nrf52-hal-common]
 path = "../nrf52-hal-common"
+default-features = false
 features = ["52832"]
 version = "=0.6.0-beta.1"
 

--- a/nrf52832-hal/Cargo.toml
+++ b/nrf52832-hal/Cargo.toml
@@ -30,6 +30,7 @@ version = "0.2.2"
 [dependencies.nrf52-hal-common]
 path = "../nrf52-hal-common"
 features = ["52832"]
+version = "=0.6.0-beta.1"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52832-hal/Cargo.toml
+++ b/nrf52832-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52832-hal"
-version = "0.6.0-beta.4"
+version = "0.6.0"
 description = "HAL for nRF52832 microcontrollers"
 
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -17,7 +17,7 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.5.8"
 nb = "0.1.1"
-nrf52832-pac = "0.6.0-beta.2"
+nrf52832-pac = "0.6.0"
 
 [dependencies.void]
 default-features = false
@@ -31,7 +31,7 @@ version = "0.2.2"
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52832"]
-version = "=0.6.0-beta.3"
+version = "=0.6.0"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52832-hal/Cargo.toml
+++ b/nrf52832-hal/Cargo.toml
@@ -1,31 +1,35 @@
 [package]
+name = "nrf52832-hal"
+version = "0.6.0-beta.1"
+description = "HAL for nRF52832 microcontrollers"
+
+repository = "https://github.com/nrf-rs/nrf52-hal"
 authors = [
-    "James Munns <james.munns@gmail.com>",
+    "James Munns <james@onevariable.com>",
     "Hanno Braun <hanno@braun-robotics.com"
 ]
+
 categories = ["embedded", "hardware-support", "no-std"]
-description = "HAL for nRF52832 microcontrollers"
-keywords = ["arm", "cortex-m", "nrf52", "hal"]
+keywords = ["arm", "cortex-m", "nrf52", "hal", "nrf52832"]
 license = "MIT OR Apache-2.0"
-name = "nrf52832-hal"
-repository = "https://github.com/nrf-rs/nrf52-hal"
-version = "0.0.1"
+edition = "2018"
 
 [dependencies]
-cortex-m = "0.5.4"
+cortex-m = "0.5.8"
 nb = "0.1.1"
-void = { version = "1", default-features = false }
+nrf52832-pac = "0.6.0-beta.1"
 
-[dependencies.nrf52-hal-common]
-path = "../nrf52-hal-common"
-features = ["52832"]
-
-[dependencies.nrf52]
-version = "0.4.0"
+[dependencies.void]
+default-features = false
+version = "1.0.2"
 
 [dependencies.cast]
 default-features = false
 version = "0.2.2"
+
+[dependencies.nrf52-hal-common]
+path = "../nrf52-hal-common"
+features = ["52832"]
 
 [dependencies.embedded-hal]
 features = ["unproven"]
@@ -33,6 +37,6 @@ version = "0.2.1"
 
 [features]
 doc = []
-rt = ["nrf52/rt"]
+rt = ["nrf52832-pac/rt"]
 default = ["rt"]
 

--- a/nrf52832-hal/Cargo.toml
+++ b/nrf52832-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52832-hal"
-version = "0.6.0-beta.2"
+version = "0.6.0-beta.3"
 description = "HAL for nRF52832 microcontrollers"
 
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -17,7 +17,7 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.5.8"
 nb = "0.1.1"
-nrf52832-pac = "0.6.0-beta.1"
+nrf52832-pac = "0.6.0-beta.2"
 
 [dependencies.void]
 default-features = false
@@ -31,7 +31,7 @@ version = "0.2.2"
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52832"]
-version = "=0.6.0-beta.2"
+version = "=0.6.0-beta.3"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52832-hal/Cargo.toml
+++ b/nrf52832-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52832-hal"
-version = "0.6.0-beta.3"
+version = "0.6.0-beta.4"
 description = "HAL for nRF52832 microcontrollers"
 
 repository = "https://github.com/nrf-rs/nrf52-hal"

--- a/nrf52832-hal/Cargo.toml
+++ b/nrf52832-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52832-hal"
-version = "0.6.0-beta.1"
+version = "0.6.0-beta.2"
 description = "HAL for nRF52832 microcontrollers"
 
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -31,7 +31,7 @@ version = "0.2.2"
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52832"]
-version = "=0.6.0-beta.1"
+version = "=0.6.0-beta.2"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52832-hal/Cargo.toml
+++ b/nrf52832-hal/Cargo.toml
@@ -31,7 +31,7 @@ version = "0.2.2"
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52832"]
-version = "=0.6.0"
+version = "0.6.0"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52832-hal/Xargo.toml
+++ b/nrf52832-hal/Xargo.toml
@@ -1,6 +1,0 @@
-[dependencies.core]
-stage = 0
-
-[dependencies.compiler_builtins]
-features = ["mem"]
-stage = 1

--- a/nrf52832-hal/build.rs
+++ b/nrf52832-hal/build.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 
-pub fn main() {
+fn main() {
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
     File::create(out.join("memory.x"))

--- a/nrf52832-hal/memory.x
+++ b/nrf52832-hal/memory.x
@@ -1,6 +1,23 @@
 /* Linker script for the nRF52 - WITHOUT SOFT DEVICE */
 MEMORY
 {
+  /* NOTE K = KiBi = 1024 bytes */
   FLASH : ORIGIN = 0x00000000, LENGTH = 128K
   RAM : ORIGIN = 0x20000000, LENGTH = 64K
 }
+
+/* This is where the call stack will be allocated. */
+/* The stack is of the full descending type. */
+/* You may want to use this variable to locate the call stack and static
+   variables in different memory regions. Below is shown the default value */
+/* _stack_start = ORIGIN(RAM) + LENGTH(RAM); */
+
+/* You can use this symbol to customize the location of the .text section */
+/* If omitted the .text section will be placed right after the .vector_table
+   section */
+/* This is required only on microcontrollers that store some configuration right
+   after the vector table */
+/* _stext = ORIGIN(FLASH) + 0x400; */
+
+/* Size of the heap (in bytes) */
+/* _heap_size = 1024; */

--- a/nrf52832-hal/src/lib.rs
+++ b/nrf52832-hal/src/lib.rs
@@ -1,25 +1,23 @@
 #![no_std]
 
-extern crate embedded_hal as hal;
-pub extern crate nrf52;
-extern crate nrf52_hal_common;
-
-pub use nrf52_hal_common::*;
+use embedded_hal as hal;
+pub use nrf52832_pac;
+pub use nrf52_hal_common::{self, *};
 
 pub mod prelude {
-    pub use hal::prelude::*;
+    pub use crate::hal::prelude::*;
     pub use nrf52_hal_common::prelude::*;
 
-    pub use clocks::ClocksExt;
-    pub use gpio::GpioExt;
-    pub use spim::SpimExt;
-    pub use time::U32Ext;
-    pub use timer::TimerExt;
-    pub use uarte::UarteExt;
+    pub use crate::clocks::ClocksExt;
+    pub use crate::gpio::GpioExt;
+    pub use crate::spim::SpimExt;
+    pub use crate::time::U32Ext;
+    pub use crate::timer::TimerExt;
+    pub use crate::uarte::UarteExt;
 }
 
-pub use clocks::Clocks;
-pub use delay::Delay;
-pub use spim::Spim;
-pub use timer::Timer;
-pub use uarte::Uarte;
+pub use crate::clocks::Clocks;
+pub use crate::delay::Delay;
+pub use crate::spim::Spim;
+pub use crate::timer::Timer;
+pub use crate::uarte::Uarte;

--- a/nrf52832-hal/src/lib.rs
+++ b/nrf52832-hal/src/lib.rs
@@ -2,7 +2,7 @@
 
 use embedded_hal as hal;
 pub use nrf52832_pac;
-pub use nrf52_hal_common::{self, *};
+pub use nrf52_hal_common::*;
 
 pub mod prelude {
     pub use crate::hal::prelude::*;

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52840-hal"
-version = "0.6.0-beta.1"
+version = "0.6.0-beta.2"
 description = "HAL for nRF52840 microcontrollers"
 
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -33,7 +33,7 @@ version = "0.2.2"
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52840"]
-version = "=0.6.0-beta.1"
+version = "=0.6.0-beta.2"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52840-hal"
-version = "0.6.0-beta.2"
+version = "0.6.0-beta.3"
 description = "HAL for nRF52840 microcontrollers"
 
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -19,7 +19,7 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.5.8"
 nb = "0.1.1"
-nrf52840-pac = "=0.6.0-beta.1"
+nrf52840-pac = "=0.6.0-beta.2"
 
 [dependencies.void]
 default-features = false
@@ -33,7 +33,7 @@ version = "0.2.2"
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52840"]
-version = "=0.6.0-beta.2"
+version = "=0.6.0-beta.3"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -6,7 +6,7 @@ description = "HAL for nRF52840 microcontrollers"
 repository = "https://github.com/nrf-rs/nrf52-hal"
 authors = [
     "James Munns <james@onevariable.com>",
-    "Hanno Braun <hanno@braun-robotics.com",
+    "Hanno Braun <hanno@braun-robotics.com>",
     "John Scarrott <johnps@outlook.com>",
     "Wez Furlong <wez@wezfurlong.org>",
 ]
@@ -31,6 +31,7 @@ version = "0.2.2"
 
 [dependencies.nrf52-hal-common]
 path = "../nrf52-hal-common"
+default-features = false
 features = ["52840"]
 version = "=0.6.0-beta.1"
 

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52840-hal"
-version = "0.6.0-beta.4"
+version = "0.6.0"
 description = "HAL for nRF52840 microcontrollers"
 
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -19,7 +19,7 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.5.8"
 nb = "0.1.1"
-nrf52840-pac = "=0.6.0-beta.2"
+nrf52840-pac = "=0.6.0"
 
 [dependencies.void]
 default-features = false
@@ -33,7 +33,7 @@ version = "0.2.2"
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52840"]
-version = "=0.6.0-beta.3"
+version = "=0.6.0"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -32,6 +32,7 @@ version = "0.2.2"
 [dependencies.nrf52-hal-common]
 path = "../nrf52-hal-common"
 features = ["52840"]
+version = "=0.6.0-beta.1"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -1,21 +1,29 @@
 [package]
 name = "nrf52840-hal"
-version = "0.1.0"
+version = "0.6.0-beta.1"
+description = "HAL for nRF52840 microcontrollers"
+
+repository = "https://github.com/nrf-rs/nrf52-hal"
 authors = [
-    "James Munns <james.munns@gmail.com>",
+    "James Munns <james@onevariable.com>",
     "Hanno Braun <hanno@braun-robotics.com",
     "John Scarrott <johnps@outlook.com>",
     "Wez Furlong <wez@wezfurlong.org>",
 ]
-repository = "https://github.com/nrf-rs/nrf52-hal"
-description = "HAL for nRF52840 microcontrollers"
+
+categories = ["embedded", "hardware-support", "no-std"]
+keywords = ["arm", "cortex-m", "nrf52", "hal", "nrf52840"]
+license = "MIT OR Apache-2.0"
+edition = "2018"
 
 [dependencies]
-bare-metal = "0.2.0"
-cortex-m = "0.5.2"
-cortex-m-rt = "0.5.1"
+cortex-m = "0.5.8"
 nb = "0.1.1"
-nrf52840 = "0.2.0"
+nrf52840-pac = "=0.6.0-beta.1"
+
+[dependencies.void]
+default-features = false
+version = "1.0.2"
 
 [dependencies.cast]
 default-features = false
@@ -29,11 +37,8 @@ features = ["52840"]
 features = ["unproven"]
 version = "0.2.1"
 
-[dependencies.void]
-default-features = false
-version = "1.0.2"
-
 [features]
+doc = []
+rt = ["nrf52840-pac/rt"]
 default = ["rt"]
-rt = ["nrf52840/rt"]
 

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.5.8"
 nb = "0.1.1"
-nrf52840-pac = "=0.6.0"
+nrf52840-pac = "0.6.0"
 
 [dependencies.void]
 default-features = false

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52840-hal"
-version = "0.6.0-beta.3"
+version = "0.6.0-beta.4"
 description = "HAL for nRF52840 microcontrollers"
 
 repository = "https://github.com/nrf-rs/nrf52-hal"

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -33,7 +33,7 @@ version = "0.2.2"
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52840"]
-version = "=0.6.0"
+version = "0.6.0"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52840-hal/memory.x
+++ b/nrf52840-hal/memory.x
@@ -1,3 +1,4 @@
+/* Linker script for the nRF52 - WITHOUT SOFT DEVICE */
 MEMORY
 {
   /* NOTE K = KiBi = 1024 bytes */

--- a/nrf52840-hal/src/lib.rs
+++ b/nrf52840-hal/src/lib.rs
@@ -2,7 +2,7 @@
 
 use embedded_hal as hal;
 pub use nrf52840_pac;
-pub use nrf52_hal_common::{self, *};
+pub use nrf52_hal_common::*;
 
 pub mod prelude {
     pub use crate::hal::prelude::*;

--- a/nrf52840-hal/src/lib.rs
+++ b/nrf52840-hal/src/lib.rs
@@ -1,24 +1,23 @@
 #![no_std]
 
-extern crate embedded_hal as hal;
-pub extern crate nrf52840;
-extern crate nrf52_hal_common;
-
-pub use nrf52_hal_common::*;
+use embedded_hal as hal;
+pub use nrf52840_pac;
+pub use nrf52_hal_common::{self, *};
 
 pub mod prelude {
-    pub use hal::prelude::*;
+    pub use crate::hal::prelude::*;
     pub use nrf52_hal_common::prelude::*;
 
-    pub use clocks::ClocksExt;
-    pub use gpio::GpioExt;
-    pub use spim::SpimExt;
-    pub use time::U32Ext;
-    pub use timer::TimerExt;
+    pub use crate::clocks::ClocksExt;
+    pub use crate::gpio::GpioExt;
+    pub use crate::spim::SpimExt;
+    pub use crate::time::U32Ext;
+    pub use crate::timer::TimerExt;
+    pub use crate::uarte::UarteExt;
 }
 
-
-pub use clocks::Clocks;
-pub use delay::Delay;
-pub use spim::Spim;
-pub use timer::Timer;
+pub use crate::clocks::Clocks;
+pub use crate::delay::Delay;
+pub use crate::spim::Spim;
+pub use crate::timer::Timer;
+pub use crate::uarte::Uarte;


### PR DESCRIPTION
* Update for 2018 edition
* Harmonize versions to 0.6.0-beta.1, matching -pac crates
* Update dependencies
* Massage some differences between 832 and 840 to be more consistent
* Remove Xargo.toml from 840
* Update my email address

All PRs in this family:

* [nrf52832-pac]
* [nrf52840-pac]
* [nrf52-hal]

[nrf52832-pac]: https://github.com/nrf-rs/nrf52832-pac/pull/11
[nrf52840-pac]: https://github.com/nrf-rs/nrf52840-pac/pull/2
[nrf52-hal]: https://github.com/nrf-rs/nrf52-hal/pull/32