### PR TITLE
Conservative fences

### DIFF
--- a/nrf52-hal-common/src/rng.rs
+++ b/nrf52-hal-common/src/rng.rs
@@ -4,6 +4,7 @@
 
 
 use core::ops::Deref;
+use core::sync::atomic::{compiler_fence, Ordering::AcqRel};
 
 use crate::target::{
     rng,
@@ -41,6 +42,10 @@ impl Rng {
 
             *b = self.0.value.read().value().bits();
         }
+
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account DMA
+        compiler_fence(AcqRel);
 
         self.0.tasks_stop.write(|w| unsafe { w.bits(1) });
     }

--- a/nrf52-hal-common/src/rng.rs
+++ b/nrf52-hal-common/src/rng.rs
@@ -4,7 +4,6 @@
 
 
 use core::ops::Deref;
-use core::sync::atomic::{compiler_fence, Ordering::AcqRel};
 
 use crate::target::{
     rng,
@@ -42,10 +41,6 @@ impl Rng {
 
             *b = self.0.value.read().value().bits();
         }
-
-        // Conservative compiler fence to prevent optimizations that do not
-        // take in to account DMA
-        compiler_fence(AcqRel);
 
         self.0.tasks_stop.write(|w| unsafe { w.bits(1) });
     }

--- a/nrf52-hal-common/src/spim.rs
+++ b/nrf52-hal-common/src/spim.rs
@@ -128,6 +128,11 @@ impl<T> Spim<T> where T: SpimExt {
         // Pull chip select pin high, which is the inactive state
         chip_select.set_high();
 
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account actions by DMA. The fence has been placed here,
+        // before any DMA action has started
+        compiler_fence(SeqCst);
+
         // Set up the DMA write
         self.0.txd.ptr.write(|w|
             // We're giving the register a pointer to the stack. Since we're
@@ -217,6 +222,11 @@ impl<T> Spim<T> where T: SpimExt {
 
         // Pull chip select pin high, which is the inactive state
         chip_select.set_high();
+
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account actions by DMA. The fence has been placed here,
+        // before any DMA action has started
+        compiler_fence(SeqCst);
 
         // Set up the DMA write
         self.0.txd.ptr.write(|w|

--- a/nrf52-hal-common/src/spim.rs
+++ b/nrf52-hal-common/src/spim.rs
@@ -2,6 +2,7 @@
 //!
 //! See product specification, chapter 31.
 use core::ops::Deref;
+use core::sync::atomic::{compiler_fence, Ordering::AcqRel};
 
 use crate::target::{
     spim0,
@@ -188,6 +189,10 @@ impl<T> Spim<T> where T: SpimExt {
             return Err(Error::Receive);
         }
 
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account DMA
+        compiler_fence(AcqRel);
+
         Ok(())
     }
 
@@ -258,6 +263,10 @@ impl<T> Spim<T> where T: SpimExt {
         if self.0.txd.amount.read().bits() != tx_buffer.len() as u32 {
             return Err(Error::Transmit);
         }
+
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account DMA
+        compiler_fence(AcqRel);
 
         Ok(())
     }

--- a/nrf52-hal-common/src/twim.rs
+++ b/nrf52-hal-common/src/twim.rs
@@ -118,6 +118,11 @@ impl<T> Twim<T> where T: TwimExt {
             return Err(Error::BufferTooLong);
         }
 
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account actions by DMA. The fence has been placed here,
+        // before any DMA action has started
+        compiler_fence(SeqCst);
+
         self.0.address.write(|w| unsafe { w.address().bits(address) });
 
         // Set up the DMA write
@@ -184,6 +189,11 @@ impl<T> Twim<T> where T: TwimExt {
         if buffer.len() > u8::max_value() as usize {
             return Err(Error::BufferTooLong);
         }
+
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account actions by DMA. The fence has been placed here,
+        // before any DMA action has started
+        compiler_fence(SeqCst);
 
         self.0.address.write(|w| unsafe { w.address().bits(address) });
 
@@ -262,6 +272,11 @@ impl<T> Twim<T> where T: TwimExt {
         if rd_buffer.len() > u8::max_value() as usize {
             return Err(Error::BufferTooLong);
         }
+
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account actions by DMA. The fence has been placed here,
+        // before any DMA action has started
+        compiler_fence(SeqCst);
 
         self.0.address.write(|w| unsafe { w.address().bits(address) });
 

--- a/nrf52-hal-common/src/twim.rs
+++ b/nrf52-hal-common/src/twim.rs
@@ -240,6 +240,110 @@ impl<T> Twim<T> where T: TwimExt {
         Ok(())
     }
 
+    /// Write data to an I2C slave, then read data from the slave without
+    /// triggering a stop condition between the two
+    ///
+    /// The buffer must have a length of at most 255 bytes.
+    pub fn write_then_read(&mut self,
+        address: u8,
+        wr_buffer:  &[u8],
+        rd_buffer: &mut [u8],
+    )
+        -> Result<(), Error>
+    {
+        // This is overly restrictive. See:
+        // https://github.com/nrf-rs/nrf52-hal/issues/17
+        if wr_buffer.len() > u8::max_value() as usize {
+            return Err(Error::BufferTooLong);
+        }
+
+        if rd_buffer.len() > u8::max_value() as usize {
+            return Err(Error::BufferTooLong);
+        }
+
+        self.0.address.write(|w| unsafe { w.address().bits(address) });
+
+        // Set up the DMA write
+        self.0.txd.ptr.write(|w|
+            // We're giving the register a pointer to the stack. Since we're
+            // waiting for the I2C transaction to end before this stack pointer
+            // becomes invalid, there's nothing wrong here.
+            //
+            // The PTR field is a full 32 bits wide and accepts the full range
+            // of values.
+            unsafe { w.ptr().bits(wr_buffer.as_ptr() as u32) }
+        );
+        self.0.txd.maxcnt.write(|w|
+            // We're giving it the length of the buffer, so no danger of
+            // accessing invalid memory. We have verified that the length of the
+            // buffer fits in an `u8`, so the cast to `u8` is also fine.
+            //
+            // The MAXCNT field is 8 bits wide and accepts the full range of
+            // values.
+            unsafe { w.maxcnt().bits(wr_buffer.len() as _) }
+        );
+
+        // Set up the DMA read
+        self.0.rxd.ptr.write(|w|
+            // We're giving the register a pointer to the stack. Since we're
+            // waiting for the I2C transaction to end before this stack pointer
+            // becomes invalid, there's nothing wrong here.
+            //
+            // The PTR field is a full 32 bits wide and accepts the full range
+            // of values.
+            unsafe { w.ptr().bits(rd_buffer.as_mut_ptr() as u32) }
+        );
+        self.0.rxd.maxcnt.write(|w|
+            // We're giving it the length of the buffer, so no danger of
+            // accessing invalid memory. We have verified that the length of the
+            // buffer fits in an `u8`, so the cast to the type of maxcnt
+            // is also fine.
+            //
+            // Note that that nrf52840 maxcnt is a wider
+            // type than a u8, so we use a `_` cast rather than a `u8` cast.
+            // The MAXCNT field is thus at least 8 bits wide and accepts the
+            // full range of values that fit in a `u8`.
+            unsafe { w.maxcnt().bits(rd_buffer.len() as _) }
+        );
+
+        // Immediately start RX after TX, then stop
+        self.0.shorts.modify(|_r, w|
+            w.lasttx_startrx().enabled()
+             .lastrx_stop().enabled()
+        );
+
+        // Start write operation
+        self.0.tasks_starttx.write(|w|
+            // `1` is a valid value to write to task registers.
+            unsafe { w.bits(1) }
+        );
+
+        // Wait until total operation has ended
+        while self.0.events_stopped.read().bits() == 0 {}
+
+        self.0.events_lasttx.write(|w| w); // reset event
+        self.0.events_lastrx.write(|w| w); // reset event
+        self.0.events_stopped.write(|w| w); // reset event
+        self.0.shorts.write(|w| w);
+
+        let bad_write = self.0.txd.amount.read().bits() != wr_buffer.len() as u32;
+        let bad_read  = self.0.rxd.amount.read().bits() != rd_buffer.len() as u32;
+
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account DMA
+        compiler_fence(AcqRel);
+
+        if bad_write {
+            return Err(Error::Transmit);
+        }
+
+        if bad_read {
+            return Err(Error::Receive);
+        }
+
+        Ok(())
+    }
+
     /// Return the raw interface to the underlying TWIM peripheral
     pub fn free(self) -> T {
         self.0

--- a/nrf52-hal-common/src/twim.rs
+++ b/nrf52-hal-common/src/twim.rs
@@ -4,9 +4,8 @@
 //!
 //! - nrf52832: Section 33
 //! - nrf52840: Section 6.31
-
-
 use core::ops::Deref;
+use core::sync::atomic::{compiler_fence, Ordering::AcqRel};
 
 use crate::target::{
     twim0,
@@ -165,6 +164,10 @@ impl<T> Twim<T> where T: TwimExt {
             return Err(Error::Transmit);
         }
 
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account DMA
+        compiler_fence(AcqRel);
+
         Ok(())
     }
 
@@ -229,6 +232,10 @@ impl<T> Twim<T> where T: TwimExt {
         if self.0.rxd.amount.read().bits() != buffer.len() as u32 {
             return Err(Error::Receive);
         }
+
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account DMA
+        compiler_fence(AcqRel);
 
         Ok(())
     }

--- a/nrf52-hal-common/src/uarte.rs
+++ b/nrf52-hal-common/src/uarte.rs
@@ -115,6 +115,11 @@ impl<T> Uarte<T> where T: UarteExt {
             return Err(Error::TxBufferTooLong);
         }
 
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account actions by DMA. The fence has been placed here,
+        // before any DMA action has started
+        compiler_fence(SeqCst);
+
         // Set up the DMA write
         self.0.txd.ptr.write(|w|
             // We're giving the register a pointer to the stack. Since we're

--- a/nrf52-hal-common/src/uarte.rs
+++ b/nrf52-hal-common/src/uarte.rs
@@ -5,7 +5,7 @@
 //! - nrf52832: Section 35
 //! - nrf52840: Section 6.34
 use core::ops::Deref;
-use core::sync::atomic::{compiler_fence, Ordering::AcqRel};
+use core::sync::atomic::{compiler_fence, Ordering::SeqCst};
 
 use crate::target::{
     uarte0,
@@ -146,8 +146,9 @@ impl<T> Uarte<T> where T: UarteExt {
         self.0.events_endtx.write(|w| w);
 
         // Conservative compiler fence to prevent optimizations that do not
-        // take in to account DMA
-        compiler_fence(AcqRel);
+        // take in to account actions by DMA. The fence has been placed here,
+        // after all possible DMA actions have completed
+        compiler_fence(SeqCst);
 
         if self.0.txd.amount.read().bits() != tx_buffer.len() as u32 {
             return Err(Error::Transmit);

--- a/nrf52-hal-common/src/uarte.rs
+++ b/nrf52-hal-common/src/uarte.rs
@@ -4,8 +4,8 @@
 //!
 //! - nrf52832: Section 35
 //! - nrf52840: Section 6.34
-
 use core::ops::Deref;
+use core::sync::atomic::{compiler_fence, Ordering::AcqRel};
 
 use crate::target::{
     uarte0,
@@ -148,6 +148,10 @@ impl<T> Uarte<T> where T: UarteExt {
         if self.0.txd.amount.read().bits() != tx_buffer.len() as u32 {
             return Err(Error::Transmit);
         }
+
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account DMA
+        compiler_fence(AcqRel);
 
         Ok(())
     }

--- a/nrf52-hal-common/src/uarte.rs
+++ b/nrf52-hal-common/src/uarte.rs
@@ -145,13 +145,13 @@ impl<T> Uarte<T> where T: UarteExt {
         // Reset the event, otherwise it will always read `1` from now on.
         self.0.events_endtx.write(|w| w);
 
-        if self.0.txd.amount.read().bits() != tx_buffer.len() as u32 {
-            return Err(Error::Transmit);
-        }
-
         // Conservative compiler fence to prevent optimizations that do not
         // take in to account DMA
         compiler_fence(AcqRel);
+
+        if self.0.txd.amount.read().bits() != tx_buffer.len() as u32 {
+            return Err(Error::Transmit);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Hey all,

This change introduces two major things:

* Uses an `AcqRel` compiler fence before the end of each driver function that invokes DMA, to prevent misoptimization
* Adds my `write_read` interface to TWIM, useful for I2C devices that implement a typical register interface (write address/subaddress, then read data)

The target for this merge is the re-release branch.

Closes https://github.com/nrf-rs/nrf52-hal/issues/33 - at least hopefully.