### PR TITLE
Version 0.6.1 Release

### DIFF
--- a/nrf52-hal-common/Cargo.toml
+++ b/nrf52-hal-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52-hal-common"
-version = "0.6.0"
+version = "0.6.1"
 description = "Common HAL for the nRF52 family of microcontrollers.  More specific HAL crates also exist."
 
 repository = "https://github.com/nrf-rs/nrf52-hal"

--- a/nrf52832-hal/Cargo.toml
+++ b/nrf52832-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52832-hal"
-version = "0.6.0"
+version = "0.6.1"
 description = "HAL for nRF52832 microcontrollers"
 
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -31,7 +31,7 @@ version = "0.2.2"
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52832"]
-version = "0.6.0"
+version = "=0.6.1"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52832-hal/Cargo.toml
+++ b/nrf52832-hal/Cargo.toml
@@ -31,7 +31,7 @@ version = "0.2.2"
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52832"]
-version = "=0.6.1"
+version = "0.6.1"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52840-hal"
-version = "0.6.0"
+version = "0.6.1"
 description = "HAL for nRF52840 microcontrollers"
 
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -33,7 +33,7 @@ version = "0.2.2"
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52840"]
-version = "0.6.0"
+version = "=0.6.1"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -33,7 +33,7 @@ version = "0.2.2"
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52840"]
-version = "=0.6.1"
+version = "0.6.1"
 
 [dependencies.embedded-hal]
 features = ["unproven"]


### PR DESCRIPTION
Issuing a point release to include the support for pullups for GPIOs.

NB: I have changed the dependencies in the `nrf528xx-hal` crates to use an **exact** dependency on the `nrf52-hal-common` crate. I do not believe there would be a case where you would ever want the `-hal` and `-hal-common` to differ, so this matches the "works as expected" case IMO.