### PR TITLE
Implemented embedded_hal Transfer trait for SPIM and removed EasyDMA limitation for UARTE and TWIM

### DIFF
--- a/nrf52-hal-common/src/lib.rs
+++ b/nrf52-hal-common/src/lib.rs
@@ -30,7 +30,7 @@ pub mod prelude {
     pub use crate::twim::TwimExt;
     pub use crate::uarte::UarteExt;
 }
-/// Length of Nordoc EasyDMA differs for MCUs
+/// Length of Nordic EasyDMA differs for MCUs
 const fn easy_dma_size() -> usize {
     // NRF52832 8 bits1..0xFF
     #[cfg(feature = "52832")]

--- a/nrf52-hal-common/src/lib.rs
+++ b/nrf52-hal-common/src/lib.rs
@@ -30,15 +30,20 @@ pub mod prelude {
     pub use crate::twim::TwimExt;
     pub use crate::uarte::UarteExt;
 }
+
 /// Length of Nordic EasyDMA differs for MCUs
-const fn easy_dma_size() -> usize {
+#[cfg(feature = "52832")]
+pub mod target_constants{
     // NRF52832 8 bits1..0xFF
-    #[cfg(feature = "52832")]
-    {255}
-    // NRF52840 16 bits 1..0xFFFF
-    #[cfg(feature = "52840")]
-    {65535}
+    pub const EASY_DMA_SIZE:usize = 255;
 }
+    // NRF52840 16 bits 1..0xFFFF
+#[cfg(feature = "52840")]
+pub mod target_constants{
+    pub const EASY_DMA_SIZE:usize = 65535;
+}
+
+
 pub use crate::clocks::Clocks;
 pub use crate::delay::Delay;
 pub use crate::spim::Spim;

--- a/nrf52-hal-common/src/lib.rs
+++ b/nrf52-hal-common/src/lib.rs
@@ -30,8 +30,15 @@ pub mod prelude {
     pub use crate::twim::TwimExt;
     pub use crate::uarte::UarteExt;
 }
-
-
+/// Length of Nordoc EasyDMA differs for MCUs
+const fn easy_dma_size() -> usize {
+    // NRF52832 8 bits1..0xFF
+    #[cfg(feature = "52832")]
+    {255}
+    // NRF52840 16 bits 1..0xFFFF
+    #[cfg(feature = "52840")]
+    {65535}
+}
 pub use crate::clocks::Clocks;
 pub use crate::delay::Delay;
 pub use crate::spim::Spim;

--- a/nrf52-hal-common/src/spim.rs
+++ b/nrf52-hal-common/src/spim.rs
@@ -75,7 +75,7 @@ impl<T> Transfer<u8> for Spim<T> where T: SpimExt
 
         let mut offset:u32 = 0;
         while offset < words.len() as u32 {
-            let datalen = min(MAX_SPI_DMA_SIZE,(words.len() as u32 )- offset);
+            let datalen = min(MAX_SPI_DMA_SIZE, (words.len() as u32) - offset);
             let dataptr = offset + (words.as_ptr() as u32);
             offset += MAX_SPI_DMA_SIZE;
 

--- a/nrf52-hal-common/src/spim.rs
+++ b/nrf52-hal-common/src/spim.rs
@@ -13,7 +13,7 @@ use crate::target::{
     SPIM2,
 };
 
-use crate::easy_dma_size;
+use crate::target_constants::EASY_DMA_SIZE;
 use crate::prelude::*;
 use crate::gpio::{
     p0::P0_Pin,
@@ -63,9 +63,9 @@ impl<T> Transfer<u8> for Spim<T> where T: SpimExt
     fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Error> {
         let mut offset:usize = 0;
         while offset < words.len() {
-            let datalen = min(easy_dma_size(), words.len()  - offset);
+            let datalen = min(EASY_DMA_SIZE, words.len()  - offset);
             let dataptr = offset + (words.as_ptr() as usize);
-            offset += easy_dma_size();
+            offset += EASY_DMA_SIZE;
 
             self.do_spi_dma_transfer(dataptr as u32,datalen as u32,dataptr as u32,datalen as u32,|_|{})?;
 
@@ -234,10 +234,10 @@ impl<T> Spim<T> where T: SpimExt {
     )
         -> Result<(), Error>
     {
-        if tx_buffer.len() > easy_dma_size() {
+        if tx_buffer.len() > EASY_DMA_SIZE {
             return Err(Error::TxBufferTooLong);
         }
-        if rx_buffer.len() > easy_dma_size() {
+        if rx_buffer.len() > EASY_DMA_SIZE {
             return Err(Error::RxBufferTooLong);
         }
 
@@ -294,7 +294,7 @@ impl<T> Spim<T> where T: SpimExt {
         -> Result<(), Error>
     {
 
-        if tx_buffer.len() > easy_dma_size() {
+        if tx_buffer.len() > EASY_DMA_SIZE {
             return Err(Error::TxBufferTooLong);
         }
 

--- a/nrf52-hal-common/src/spim.rs
+++ b/nrf52-hal-common/src/spim.rs
@@ -66,13 +66,6 @@ impl<T> Transfer<u8> for Spim<T> where T: SpimExt
    type Error = Error;
 
     fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Error> {
-        // TODO: some targets have a maxcnt whose size is larger
-        // than a u8, so this length check is overly restrictive
-        // and could be lifted.
-        if words.len() > MAX_SPI_DMA_SIZE as usize {
-            return Err(Error::TxBufferTooLong);
-        }
-
         let mut offset:u32 = 0;
         while offset < words.len() as u32 {
             let datalen = min(MAX_SPI_DMA_SIZE, (words.len() as u32) - offset);

--- a/nrf52-hal-common/src/twim.rs
+++ b/nrf52-hal-common/src/twim.rs
@@ -22,7 +22,7 @@ use crate::gpio::{
     Input,
 };
 
-use crate::easy_dma_size;
+use crate::target_constants::EASY_DMA_SIZE;
 
 pub use crate::target::twim0::frequency::FREQUENCYW as Frequency;
 
@@ -117,9 +117,9 @@ impl<T> Twim<T> where T: TwimExt {
     {
         let mut offset = 0;
         while offset < buffer.len() {
-            let datalen = min(easy_dma_size(), buffer.len() - offset);
+            let datalen = min(EASY_DMA_SIZE, buffer.len() - offset);
             let dataptr = offset + (buffer.as_ptr() as usize);
-            offset += easy_dma_size();
+            offset += EASY_DMA_SIZE;
             // Conservative compiler fence to prevent optimizations that do not
             // take in to account actions by DMA. The fence has been placed here,
             // before any DMA action has started
@@ -188,9 +188,9 @@ impl<T> Twim<T> where T: TwimExt {
     {
         let mut offset = 0;
         while offset < buffer.len() {
-            let datalen = min(easy_dma_size(), buffer.len() - offset);
+            let datalen = min(EASY_DMA_SIZE, buffer.len() - offset);
             let dataptr = offset + (buffer.as_ptr() as usize);
-            offset += easy_dma_size();
+            offset += EASY_DMA_SIZE;
 
             // Conservative compiler fence to prevent optimizations that do not
             // take in to account actions by DMA. The fence has been placed here,
@@ -265,11 +265,11 @@ impl<T> Twim<T> where T: TwimExt {
     )
         -> Result<(), Error>
     {
-        if wr_buffer.len() > easy_dma_size() {
+        if wr_buffer.len() > EASY_DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 
-        if rd_buffer.len() > easy_dma_size() {
+        if rd_buffer.len() > EASY_DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 

--- a/nrf52-hal-common/src/twim.rs
+++ b/nrf52-hal-common/src/twim.rs
@@ -5,6 +5,8 @@
 //! - nrf52832: Section 33
 //! - nrf52840: Section 6.31
 use core::ops::Deref;
+use core::cmp::min;
+
 use core::sync::atomic::{compiler_fence, Ordering::SeqCst};
 
 use crate::target::{
@@ -20,6 +22,7 @@ use crate::gpio::{
     Input,
 };
 
+use crate::easy_dma_size;
 
 pub use crate::target::twim0::frequency::FREQUENCYW as Frequency;
 
@@ -112,68 +115,67 @@ impl<T> Twim<T> where T: TwimExt {
     )
         -> Result<(), Error>
     {
-        // This is overly restrictive. See:
-        // https://github.com/nrf-rs/nrf52-hal/issues/17
-        if buffer.len() > u8::max_value() as usize {
-            return Err(Error::BufferTooLong);
+        let mut offset = 0;
+        while offset < buffer.len() {
+            let datalen = min(easy_dma_size(), buffer.len() - offset);
+            let dataptr = offset + (buffer.as_ptr() as usize);
+            offset += easy_dma_size();
+            // Conservative compiler fence to prevent optimizations that do not
+            // take in to account actions by DMA. The fence has been placed here,
+            // before any DMA action has started
+            compiler_fence(SeqCst);
+
+            self.0.address.write(|w| unsafe { w.address().bits(address) });
+
+            // Set up the DMA write
+            self.0.txd.ptr.write(|w|
+                // We're giving the register a pointer to the stack. Since we're
+                // waiting for the I2C transaction to end before this stack pointer
+                // becomes invalid, there's nothing wrong here.
+                //
+                // The PTR field is a full 32 bits wide and accepts the full range
+                // of values.
+                unsafe { w.ptr().bits(dataptr as u32) }
+            );
+            self.0.txd.maxcnt.write(|w|
+                // We're giving it the length of the buffer, so no danger of
+                // accessing invalid memory. We have verified that the length of the
+                // buffer fits in an `u8`, so the cast to `u8` is also fine.
+                //
+                // The MAXCNT field is 8 bits wide and accepts the full range of
+                // values.
+                unsafe { w.maxcnt().bits(datalen as _) }
+            );
+
+            // Start write operation
+            self.0.tasks_starttx.write(|w|
+                // `1` is a valid value to write to task registers.
+                unsafe { w.bits(1) }
+            );
+
+            // Wait until write operation is about to end
+            while self.0.events_lasttx.read().bits() == 0 {}
+            self.0.events_lasttx.write(|w| w); // reset event
+
+            // Stop read operation
+            self.0.tasks_stop.write(|w|
+                // `1` is a valid value to write to task registers.
+                unsafe { w.bits(1) }
+            );
+
+            // Wait until write operation has ended
+            while self.0.events_stopped.read().bits() == 0 {}
+            self.0.events_stopped.write(|w| w); // reset event
+
+            // Conservative compiler fence to prevent optimizations that do not
+            // take in to account actions by DMA. The fence has been placed here,
+            // after all possible DMA actions have completed
+            compiler_fence(SeqCst);
+
+            if self.0.txd.amount.read().bits() != datalen as u32 {
+                return Err(Error::Transmit);
+            }
         }
-
-        // Conservative compiler fence to prevent optimizations that do not
-        // take in to account actions by DMA. The fence has been placed here,
-        // before any DMA action has started
-        compiler_fence(SeqCst);
-
-        self.0.address.write(|w| unsafe { w.address().bits(address) });
-
-        // Set up the DMA write
-        self.0.txd.ptr.write(|w|
-            // We're giving the register a pointer to the stack. Since we're
-            // waiting for the I2C transaction to end before this stack pointer
-            // becomes invalid, there's nothing wrong here.
-            //
-            // The PTR field is a full 32 bits wide and accepts the full range
-            // of values.
-            unsafe { w.ptr().bits(buffer.as_ptr() as u32) }
-        );
-        self.0.txd.maxcnt.write(|w|
-            // We're giving it the length of the buffer, so no danger of
-            // accessing invalid memory. We have verified that the length of the
-            // buffer fits in an `u8`, so the cast to `u8` is also fine.
-            //
-            // The MAXCNT field is 8 bits wide and accepts the full range of
-            // values.
-            unsafe { w.maxcnt().bits(buffer.len() as _) }
-        );
-
-        // Start write operation
-        self.0.tasks_starttx.write(|w|
-            // `1` is a valid value to write to task registers.
-            unsafe { w.bits(1) }
-        );
-
-        // Wait until write operation is about to end
-        while self.0.events_lasttx.read().bits() == 0 {}
-        self.0.events_lasttx.write(|w| w); // reset event
-
-        // Stop read operation
-        self.0.tasks_stop.write(|w|
-            // `1` is a valid value to write to task registers.
-            unsafe { w.bits(1) }
-        );
-
-        // Wait until write operation has ended
-        while self.0.events_stopped.read().bits() == 0 {}
-        self.0.events_stopped.write(|w| w); // reset event
-
-        // Conservative compiler fence to prevent optimizations that do not
-        // take in to account actions by DMA. The fence has been placed here,
-        // after all possible DMA actions have completed
-        compiler_fence(SeqCst);
-
-        if self.0.txd.amount.read().bits() != buffer.len() as u32 {
-            return Err(Error::Transmit);
-        }
-
         Ok(())
     }
 
@@ -184,71 +186,71 @@ impl<T> Twim<T> where T: TwimExt {
     )
         -> Result<(), Error>
     {
-        // This is overly restrictive. See:
-        // https://github.com/nrf-rs/nrf52-hal/issues/17
-        if buffer.len() > u8::max_value() as usize {
-            return Err(Error::BufferTooLong);
+        let mut offset = 0;
+        while offset < buffer.len() {
+            let datalen = min(easy_dma_size(), buffer.len() - offset);
+            let dataptr = offset + (buffer.as_ptr() as usize);
+            offset += easy_dma_size();
+
+            // Conservative compiler fence to prevent optimizations that do not
+            // take in to account actions by DMA. The fence has been placed here,
+            // before any DMA action has started
+            compiler_fence(SeqCst);
+
+            self.0.address.write(|w| unsafe { w.address().bits(address) });
+
+            // Set up the DMA read
+            self.0.rxd.ptr.write(|w|
+                // We're giving the register a pointer to the stack. Since we're
+                // waiting for the I2C transaction to end before this stack pointer
+                // becomes invalid, there's nothing wrong here.
+                //
+                // The PTR field is a full 32 bits wide and accepts the full range
+                // of values.
+                unsafe { w.ptr().bits(dataptr as u32) }
+            );
+            self.0.rxd.maxcnt.write(|w|
+                // We're giving it the length of the buffer, so no danger of
+                // accessing invalid memory. We have verified that the length of the
+                // buffer fits in an `u8`, so the cast to the type of maxcnt
+                // is also fine.
+                //
+                // Note that that nrf52840 maxcnt is a wider
+                // type than a u8, so we use a `_` cast rather than a `u8` cast.
+                // The MAXCNT field is thus at least 8 bits wide and accepts the
+                // full range of values that fit in a `u8`.
+                unsafe { w.maxcnt().bits(datalen as _) }
+            );
+
+            // Start read operation
+            self.0.tasks_startrx.write(|w|
+                // `1` is a valid value to write to task registers.
+                unsafe { w.bits(1) }
+            );
+
+            // Wait until read operation is about to end
+            while self.0.events_lastrx.read().bits() == 0 {}
+            self.0.events_lastrx.write(|w| w); // reset event
+
+            // Stop read operation
+            self.0.tasks_stop.write(|w|
+                // `1` is a valid value to write to task registers.
+                unsafe { w.bits(1) }
+            );
+
+            // Wait until read operation has ended
+            while self.0.events_stopped.read().bits() == 0 {}
+            self.0.events_stopped.write(|w| w); // reset event
+
+            // Conservative compiler fence to prevent optimizations that do not
+            // take in to account actions by DMA. The fence has been placed here,
+            // after all possible DMA actions have completed
+            compiler_fence(SeqCst);
+
+            if self.0.rxd.amount.read().bits() != datalen as u32 {
+                return Err(Error::Receive);
+            }
         }
-
-        // Conservative compiler fence to prevent optimizations that do not
-        // take in to account actions by DMA. The fence has been placed here,
-        // before any DMA action has started
-        compiler_fence(SeqCst);
-
-        self.0.address.write(|w| unsafe { w.address().bits(address) });
-
-        // Set up the DMA read
-        self.0.rxd.ptr.write(|w|
-            // We're giving the register a pointer to the stack. Since we're
-            // waiting for the I2C transaction to end before this stack pointer
-            // becomes invalid, there's nothing wrong here.
-            //
-            // The PTR field is a full 32 bits wide and accepts the full range
-            // of values.
-            unsafe { w.ptr().bits(buffer.as_mut_ptr() as u32) }
-        );
-        self.0.rxd.maxcnt.write(|w|
-            // We're giving it the length of the buffer, so no danger of
-            // accessing invalid memory. We have verified that the length of the
-            // buffer fits in an `u8`, so the cast to the type of maxcnt
-            // is also fine.
-            //
-            // Note that that nrf52840 maxcnt is a wider
-            // type than a u8, so we use a `_` cast rather than a `u8` cast.
-            // The MAXCNT field is thus at least 8 bits wide and accepts the
-            // full range of values that fit in a `u8`.
-            unsafe { w.maxcnt().bits(buffer.len() as _) }
-        );
-
-        // Start read operation
-        self.0.tasks_startrx.write(|w|
-            // `1` is a valid value to write to task registers.
-            unsafe { w.bits(1) }
-        );
-
-        // Wait until read operation is about to end
-        while self.0.events_lastrx.read().bits() == 0 {}
-        self.0.events_lastrx.write(|w| w); // reset event
-
-        // Stop read operation
-        self.0.tasks_stop.write(|w|
-            // `1` is a valid value to write to task registers.
-            unsafe { w.bits(1) }
-        );
-
-        // Wait until read operation has ended
-        while self.0.events_stopped.read().bits() == 0 {}
-        self.0.events_stopped.write(|w| w); // reset event
-
-        // Conservative compiler fence to prevent optimizations that do not
-        // take in to account actions by DMA. The fence has been placed here,
-        // after all possible DMA actions have completed
-        compiler_fence(SeqCst);
-
-        if self.0.rxd.amount.read().bits() != buffer.len() as u32 {
-            return Err(Error::Receive);
-        }
-
         Ok(())
     }
 
@@ -263,13 +265,11 @@ impl<T> Twim<T> where T: TwimExt {
     )
         -> Result<(), Error>
     {
-        // This is overly restrictive. See:
-        // https://github.com/nrf-rs/nrf52-hal/issues/17
-        if wr_buffer.len() > u8::max_value() as usize {
+        if wr_buffer.len() > easy_dma_size() {
             return Err(Error::BufferTooLong);
         }
 
-        if rd_buffer.len() > u8::max_value() as usize {
+        if rd_buffer.len() > easy_dma_size() {
             return Err(Error::BufferTooLong);
         }
 

--- a/nrf52-hal-common/src/uarte.rs
+++ b/nrf52-hal-common/src/uarte.rs
@@ -13,7 +13,7 @@ use crate::target::{
     UARTE0,
 };
 
-use crate::easy_dma_size;
+use crate::target_constants::EASY_DMA_SIZE;
 use crate::prelude::*;
 use crate::gpio::{
     p0::P0_Pin,
@@ -113,9 +113,9 @@ impl<T> Uarte<T> where T: UarteExt {
     {
         let mut offset = 0;
         while offset < tx_buffer.len() {
-            let datalen = min(easy_dma_size(), tx_buffer.len() - offset);
+            let datalen = min(EASY_DMA_SIZE, tx_buffer.len() - offset);
             let dataptr = offset + (tx_buffer.as_ptr() as usize);
-            offset += easy_dma_size();
+            offset += EASY_DMA_SIZE;
             // Conservative compiler fence to prevent optimizations that do not
             // take in to account actions by DMA. The fence has been placed here,
             // before any DMA action has started


### PR DESCRIPTION
Hi
Here is an implementation for the embedded_hal transfer trait. #10  It is based on the existing DMA setup code but CS is handled outside in embedded_hal and I set up multiple transfers if size is over the limit.

I also wrote some code for #17 not as suggested in the ticket but that could be refactored later.

