### PR TITLE
Allow larger EasyDMA buffer sizes on nrf52840

### DIFF
--- a/nrf52-hal-common/src/lib.rs
+++ b/nrf52-hal-common/src/lib.rs
@@ -35,7 +35,7 @@ pub mod prelude {
 #[cfg(feature = "52832")]
 pub mod target_constants {
     // NRF52832 8 bits1..0xFF
-    pub const EASY_DMA_SIZE:usize = 255;
+    pub const EASY_DMA_SIZE: usize = 255;
 }
     // NRF52840 16 bits 1..0xFFFF
 #[cfg(feature = "52840")]

--- a/nrf52-hal-common/src/lib.rs
+++ b/nrf52-hal-common/src/lib.rs
@@ -30,8 +30,15 @@ pub mod prelude {
     pub use crate::twim::TwimExt;
     pub use crate::uarte::UarteExt;
 }
-
-
+/// Length of Nordic EasyDMA differs for MCUs
+const fn easy_dma_size() -> usize {
+    // NRF52832 8 bits1..0xFF
+    #[cfg(feature = "52832")]
+    {255}
+    // NRF52840 16 bits 1..0xFFFF
+    #[cfg(feature = "52840")]
+    {65535}
+}
 pub use crate::clocks::Clocks;
 pub use crate::delay::Delay;
 pub use crate::spim::Spim;

--- a/nrf52-hal-common/src/lib.rs
+++ b/nrf52-hal-common/src/lib.rs
@@ -40,7 +40,7 @@ pub mod target_constants {
     // NRF52840 16 bits 1..0xFFFF
 #[cfg(feature = "52840")]
 pub mod target_constants {
-    pub const EASY_DMA_SIZE:usize = 65535;
+    pub const EASY_DMA_SIZE: usize = 65535;
 }
 
 

--- a/nrf52-hal-common/src/lib.rs
+++ b/nrf52-hal-common/src/lib.rs
@@ -30,15 +30,20 @@ pub mod prelude {
     pub use crate::twim::TwimExt;
     pub use crate::uarte::UarteExt;
 }
+
 /// Length of Nordic EasyDMA differs for MCUs
-const fn easy_dma_size() -> usize {
+#[cfg(feature = "52832")]
+pub mod target_constants{
     // NRF52832 8 bits1..0xFF
-    #[cfg(feature = "52832")]
-    {255}
-    // NRF52840 16 bits 1..0xFFFF
-    #[cfg(feature = "52840")]
-    {65535}
+    pub const EASY_DMA_SIZE:usize = 255;
 }
+    // NRF52840 16 bits 1..0xFFFF
+#[cfg(feature = "52840")]
+pub mod target_constants{
+    pub const EASY_DMA_SIZE:usize = 65535;
+}
+
+
 pub use crate::clocks::Clocks;
 pub use crate::delay::Delay;
 pub use crate::spim::Spim;

--- a/nrf52-hal-common/src/lib.rs
+++ b/nrf52-hal-common/src/lib.rs
@@ -37,12 +37,11 @@ pub mod target_constants {
     // NRF52832 8 bits1..0xFF
     pub const EASY_DMA_SIZE: usize = 255;
 }
-    // NRF52840 16 bits 1..0xFFFF
 #[cfg(feature = "52840")]
 pub mod target_constants {
+    // NRF52840 16 bits 1..0xFFFF
     pub const EASY_DMA_SIZE: usize = 65535;
 }
-
 
 pub use crate::clocks::Clocks;
 pub use crate::delay::Delay;

--- a/nrf52-hal-common/src/lib.rs
+++ b/nrf52-hal-common/src/lib.rs
@@ -39,7 +39,7 @@ pub mod target_constants {
 }
     // NRF52840 16 bits 1..0xFFFF
 #[cfg(feature = "52840")]
-pub mod target_constants{
+pub mod target_constants {
     pub const EASY_DMA_SIZE:usize = 65535;
 }
 

--- a/nrf52-hal-common/src/lib.rs
+++ b/nrf52-hal-common/src/lib.rs
@@ -33,7 +33,7 @@ pub mod prelude {
 
 /// Length of Nordic EasyDMA differs for MCUs
 #[cfg(feature = "52832")]
-pub mod target_constants{
+pub mod target_constants {
     // NRF52832 8 bits1..0xFF
     pub const EASY_DMA_SIZE:usize = 255;
 }

--- a/nrf52-hal-common/src/spim.rs
+++ b/nrf52-hal-common/src/spim.rs
@@ -224,7 +224,6 @@ impl<T> Spim<T> where T: SpimExt {
     /// This method uses the provided chip select pin to initiate the
     /// transaction, then transmits all bytes in `tx_buffer`.
     ///
-
     pub fn write(&mut self,
         chip_select: &mut P0_Pin<Output<PushPull>>,
         tx_buffer  : &[u8],

--- a/nrf52-hal-common/src/spim.rs
+++ b/nrf52-hal-common/src/spim.rs
@@ -11,6 +11,7 @@ use crate::target::{
     SPIM2,
 };
 
+use crate::easy_dma_size;
 use crate::prelude::*;
 use crate::gpio::{
     p0::P0_Pin,
@@ -134,13 +135,10 @@ impl<T> Spim<T> where T: SpimExt {
     )
         -> Result<(), Error>
     {
-        // TODO: some targets have a maxcnt whose size is larger
-        // than a u8, so this length check is overly restrictive
-        // and could be lifted.
-        if tx_buffer.len() > u8::max_value() as usize {
+        if tx_buffer.len() > easy_dma_size() {
             return Err(Error::TxBufferTooLong);
         }
-        if rx_buffer.len() > u8::max_value() as usize {
+        if rx_buffer.len() > easy_dma_size() {
             return Err(Error::RxBufferTooLong);
         }
 
@@ -226,16 +224,14 @@ impl<T> Spim<T> where T: SpimExt {
     /// This method uses the provided chip select pin to initiate the
     /// transaction, then transmits all bytes in `tx_buffer`.
     ///
-    /// The buffer must have a length of at most 255 bytes.
+
     pub fn write(&mut self,
         chip_select: &mut P0_Pin<Output<PushPull>>,
         tx_buffer  : &[u8],
     )
         -> Result<(), Error>
     {
-        // This is overly restrictive. See:
-        // https://github.com/nrf-rs/nrf52/issues/17
-        if tx_buffer.len() > u8::max_value() as usize {
+        if tx_buffer.len() > easy_dma_size() {
             return Err(Error::TxBufferTooLong);
         }
 

--- a/nrf52-hal-common/src/spim.rs
+++ b/nrf52-hal-common/src/spim.rs
@@ -11,7 +11,7 @@ use crate::target::{
     SPIM2,
 };
 
-use crate::easy_dma_size;
+use crate::target_constants::EASY_DMA_SIZE;
 use crate::prelude::*;
 use crate::gpio::{
     p0::P0_Pin,
@@ -135,10 +135,10 @@ impl<T> Spim<T> where T: SpimExt {
     )
         -> Result<(), Error>
     {
-        if tx_buffer.len() > easy_dma_size() {
+        if tx_buffer.len() > EASY_DMA_SIZE {
             return Err(Error::TxBufferTooLong);
         }
-        if rx_buffer.len() > easy_dma_size() {
+        if rx_buffer.len() > EASY_DMA_SIZE {
             return Err(Error::RxBufferTooLong);
         }
 
@@ -231,7 +231,7 @@ impl<T> Spim<T> where T: SpimExt {
     )
         -> Result<(), Error>
     {
-        if tx_buffer.len() > easy_dma_size() {
+        if tx_buffer.len() > EASY_DMA_SIZE {
             return Err(Error::TxBufferTooLong);
         }
 

--- a/nrf52-hal-common/src/twim.rs
+++ b/nrf52-hal-common/src/twim.rs
@@ -114,7 +114,7 @@ impl<T> Twim<T> where T: TwimExt {
         -> Result<(), Error>
     {
 
-        if buffer.len() >min(easy_dma_size() {
+        if buffer.len() > easy_dma_size() {
             return Err(Error::BufferTooLong);
         }
 
@@ -184,7 +184,7 @@ impl<T> Twim<T> where T: TwimExt {
     )
         -> Result<(), Error>
     {
-        if buffer.len() > min(easy_dma_size() {
+        if buffer.len() > easy_dma_size() {
             return Err(Error::BufferTooLong);
         }
 
@@ -261,11 +261,11 @@ impl<T> Twim<T> where T: TwimExt {
     )
         -> Result<(), Error>
     {
-        if wr_buffer.len() > min(easy_dma_size(){
+        if wr_buffer.len() > easy_dma_size(){
             return Err(Error::BufferTooLong);
         }
 
-        if rd_buffer.len() > min(easy_dma_size(){
+        if rd_buffer.len() > easy_dma_size(){
             return Err(Error::BufferTooLong);
         }
 

--- a/nrf52-hal-common/src/twim.rs
+++ b/nrf52-hal-common/src/twim.rs
@@ -261,7 +261,7 @@ impl<T> Twim<T> where T: TwimExt {
     )
         -> Result<(), Error>
     {
-        if wr_buffer.len() > EASY_DMA_SIZE{
+        if wr_buffer.len() > EASY_DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 

--- a/nrf52-hal-common/src/twim.rs
+++ b/nrf52-hal-common/src/twim.rs
@@ -20,6 +20,7 @@ use crate::gpio::{
     Input,
 };
 
+use crate::easy_dma_size;
 
 pub use crate::target::twim0::frequency::FREQUENCYW as Frequency;
 
@@ -112,9 +113,8 @@ impl<T> Twim<T> where T: TwimExt {
     )
         -> Result<(), Error>
     {
-        // This is overly restrictive. See:
-        // https://github.com/nrf-rs/nrf52-hal/issues/17
-        if buffer.len() > u8::max_value() as usize {
+
+        if buffer.len() >min(easy_dma_size() {
             return Err(Error::BufferTooLong);
         }
 
@@ -184,9 +184,7 @@ impl<T> Twim<T> where T: TwimExt {
     )
         -> Result<(), Error>
     {
-        // This is overly restrictive. See:
-        // https://github.com/nrf-rs/nrf52-hal/issues/17
-        if buffer.len() > u8::max_value() as usize {
+        if buffer.len() > min(easy_dma_size() {
             return Err(Error::BufferTooLong);
         }
 
@@ -263,13 +261,11 @@ impl<T> Twim<T> where T: TwimExt {
     )
         -> Result<(), Error>
     {
-        // This is overly restrictive. See:
-        // https://github.com/nrf-rs/nrf52-hal/issues/17
-        if wr_buffer.len() > u8::max_value() as usize {
+        if wr_buffer.len() > min(easy_dma_size(){
             return Err(Error::BufferTooLong);
         }
 
-        if rd_buffer.len() > u8::max_value() as usize {
+        if rd_buffer.len() > min(easy_dma_size(){
             return Err(Error::BufferTooLong);
         }
 

--- a/nrf52-hal-common/src/twim.rs
+++ b/nrf52-hal-common/src/twim.rs
@@ -265,7 +265,7 @@ impl<T> Twim<T> where T: TwimExt {
             return Err(Error::BufferTooLong);
         }
 
-        if rd_buffer.len() > EASY_DMA_SIZE{
+        if rd_buffer.len() > EASY_DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 

--- a/nrf52-hal-common/src/twim.rs
+++ b/nrf52-hal-common/src/twim.rs
@@ -20,7 +20,7 @@ use crate::gpio::{
     Input,
 };
 
-use crate::easy_dma_size;
+use crate::target_constants::EASY_DMA_SIZE;
 
 pub use crate::target::twim0::frequency::FREQUENCYW as Frequency;
 
@@ -114,7 +114,7 @@ impl<T> Twim<T> where T: TwimExt {
         -> Result<(), Error>
     {
 
-        if buffer.len() > easy_dma_size() {
+        if buffer.len() > EASY_DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 
@@ -184,7 +184,7 @@ impl<T> Twim<T> where T: TwimExt {
     )
         -> Result<(), Error>
     {
-        if buffer.len() > easy_dma_size() {
+        if buffer.len() > EASY_DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 
@@ -261,11 +261,11 @@ impl<T> Twim<T> where T: TwimExt {
     )
         -> Result<(), Error>
     {
-        if wr_buffer.len() > easy_dma_size(){
+        if wr_buffer.len() > EASY_DMA_SIZE{
             return Err(Error::BufferTooLong);
         }
 
-        if rd_buffer.len() > easy_dma_size(){
+        if rd_buffer.len() > EASY_DMA_SIZE{
             return Err(Error::BufferTooLong);
         }
 

--- a/nrf52-hal-common/src/uarte.rs
+++ b/nrf52-hal-common/src/uarte.rs
@@ -12,6 +12,7 @@ use crate::target::{
     UARTE0,
 };
 
+use crate::easy_dma_size;
 use crate::prelude::*;
 use crate::gpio::{
     p0::P0_Pin,
@@ -34,7 +35,6 @@ impl UarteExt for UARTE0 {
         Uarte::new(self, pins, parity, baudrate)
     }
 }
-
 
 /// Interface to a UARTE instance
 ///
@@ -109,9 +109,7 @@ impl<T> Uarte<T> where T: UarteExt {
     )
         -> Result<(), Error>
     {
-        // This is overly restrictive. See (similar SPIM issue):
-        // https://github.com/nrf-rs/nrf52/issues/17
-        if tx_buffer.len() > u8::max_value() as usize {
+        if tx_buffer.len() > easy_dma_size() {
             return Err(Error::TxBufferTooLong);
         }
 

--- a/nrf52-hal-common/src/uarte.rs
+++ b/nrf52-hal-common/src/uarte.rs
@@ -12,7 +12,7 @@ use crate::target::{
     UARTE0,
 };
 
-use crate::easy_dma_size;
+use crate::target_constants::EASY_DMA_SIZE;
 use crate::prelude::*;
 use crate::gpio::{
     p0::P0_Pin,
@@ -109,7 +109,7 @@ impl<T> Uarte<T> where T: UarteExt {
     )
         -> Result<(), Error>
     {
-        if tx_buffer.len() > easy_dma_size() {
+        if tx_buffer.len() > EASY_DMA_SIZE {
             return Err(Error::TxBufferTooLong);
         }
 


### PR DESCRIPTION
Expose const function in nrf52-hal-common which per platform
return limit of EasyDMA.

Closes #17