### PR TITLE
SPI Demo code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,5 @@ script:
   - cargo build --manifest-path examples/rtfm-demo/Cargo.toml
   - cargo build --manifest-path examples/rtfm-demo/Cargo.toml --no-default-features --features="52810" --target thumbv7em-none-eabi
   - cargo build --manifest-path examples/rtfm-demo/Cargo.toml --no-default-features --features="52840"
+  - cargo build --manifest-path examples/spi-demo/Cargo.toml
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "nrf52832-hal",
   "nrf52840-hal",
   "examples/rtfm-demo",
+  "examples/spi-demo",
 ]
 
 [profile.dev]

--- a/examples/spi-demo/.cargo/config
+++ b/examples/spi-demo/.cargo/config
@@ -1,0 +1,2 @@
+[target.thumbv7em-none-eabihf]
+runner = "arm-none-eabi-gdb -tui"

--- a/examples/spi-demo/Cargo.toml
+++ b/examples/spi-demo/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "spi-demo"
+version = "0.1.0"
+authors = ["Fredrik Simonsson <simson@thesimson.net>"]
+edition = "2018"
+
+[dependencies]
+cortex-m-rt = "0.6.5"
+panic-halt = "0.2.0"
+embedded-hal-spy = "0.0.3"
+
+[dependencies.embedded-hal]
+features = ["unproven"]
+version = "0.2"
+
+[dependencies.nrf52832-hal]
+version = "0.7.0"
+path = "../../nrf52832-hal"
+optional = true
+
+[dependencies.nrf52832-pac]
+version = "0.6.0"
+optional = true
+
+[features]
+52832 = ["nrf52832-hal", "nrf52832-pac"]
+default = ["52832"]
+
+[profile.release]
+opt-level = 3
+codegen-units = 1 # better optimizations
+debug = false # symbols are nice and they don't increase the size on Flash
+lto = true # better optimizations
+
+[profile.dev]
+opt-level = 0
+# codegen-units = 1 # better optimizations
+debug = true # symbols are nice and they don't increase the size on Flash

--- a/examples/spi-demo/README.md
+++ b/examples/spi-demo/README.md
@@ -1,0 +1,14 @@
+# spi-demo
+SPIM demonstation code.
+Connect a resistor between pin 22 and 23 on the demo board to feed MOSI directly back to MISO
+If all tests pass all four Led (Led1 to Led4) will light up, in case of error only at least one of the Led will remain turned off.
+
+
+## HW connections
+Pin     Connecton
+P0.24   SPIclk
+P0.23   MOSI
+P0.22   MISO
+
+This is designed for nRF52-DK board:
+https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52-DK

--- a/examples/spi-demo/src/main.rs
+++ b/examples/spi-demo/src/main.rs
@@ -48,7 +48,12 @@ fn main() -> ! {
         miso: Some(spimiso),
         mosi: Some(spimosi),
     };
-    let mut spi = p.SPIM2.constrain(pins, nrf52832_hal::spim::Frequency::K500, nrf52832_hal::spim::MODE_0, 0 );
+    let mut spi = p.SPIM2.constrain(
+        pins,
+        nrf52832_hal::spim::Frequency::K500,
+        nrf52832_hal::spim::MODE_0,
+        0,
+    );
 
     let reference_data = b"Hello,echo Loopback";
     // Read only test vector

--- a/examples/spi-demo/src/main.rs
+++ b/examples/spi-demo/src/main.rs
@@ -1,0 +1,123 @@
+#![no_std]
+#![no_main]
+
+extern crate cortex_m_rt as rt; // v0.5.x
+
+extern crate embedded_hal_spy;
+extern crate nrf52832_hal;
+extern crate panic_halt;
+use embedded_hal::blocking::spi::*;
+
+use cortex_m_rt::entry;
+use embedded_hal::digital::OutputPin;
+use nrf52832_hal::gpio;
+use nrf52832_hal::gpio::p0::*;
+use nrf52832_hal::gpio::Level;
+use nrf52832_hal::gpio::*;
+use nrf52832_hal::prelude::GpioExt;
+
+/// SPIM demonstation code.
+/// connect a resistor between pin 22 and 23 on to feed MOSI direct back to MISO
+///
+/// If all tests Led1 to 4 will light up, in case of error only the failing test
+/// one or more Led will remain off.
+#[entry]
+fn main() -> ! {
+    let p = nrf52832_hal::nrf52832_pac::Peripherals::take().unwrap();
+    let port0 = p.P0.split();
+
+    let cs: P0_21<gpio::Output<PushPull>> = port0.p0_21.into_push_pull_output(Level::Low);
+
+    let mut led1: P0_17<gpio::Output<PushPull>> = port0.p0_17.into_push_pull_output(Level::High);
+    let mut led2: P0_18<gpio::Output<PushPull>> = port0.p0_18.into_push_pull_output(Level::High);
+    let mut led3: P0_19<gpio::Output<PushPull>> = port0.p0_19.into_push_pull_output(Level::High);
+    let mut led4: P0_20<gpio::Output<PushPull>> = port0.p0_20.into_push_pull_output(Level::High);
+
+    let _btn1 = port0.p0_13.into_pullup_input();
+    let _btn2 = port0.p0_14.into_pullup_input();
+    let _btn3 = port0.p0_15.into_pullup_input();
+    let _btn4 = port0.p0_16.into_pullup_input();
+
+    let spiclk = port0.p0_24.into_push_pull_output(Level::Low).degrade();
+    let spimosi = port0.p0_23.into_push_pull_output(Level::Low).degrade();
+    let spimiso = port0.p0_22.into_floating_input().degrade();
+
+    let mut tests_ok = true;
+    let pins = nrf52832_hal::spim::Pins {
+        sck: spiclk,
+        miso: Some(spimiso),
+        mosi: Some(spimosi),
+    };
+    let mut spi = p.SPIM2.constrain(pins);
+
+    let reference_data = b"Hello,echo Loopback";
+    // Read only test vector
+    let test_vec1 = *reference_data;
+    let mut readbuf = [0; 255];
+    use nrf52832_hal::spim::SpimExt;
+
+    // This will write 8 bytes, then shift out ORC
+
+    // Note :     spi.read( &mut cs.degrade(), reference_data, &mut readbuf )
+    //            will fail because reference data is in flash, the copy to
+    //            an array will move it to RAM.
+
+    match spi.read(&mut cs.degrade(), &test_vec1, &mut readbuf) {
+        Ok(_) => {
+            for i in 0..test_vec1.len() {
+                tests_ok &= test_vec1[i] == readbuf[i];
+            }
+            if !tests_ok {
+                led1.set_low();
+            } else {
+                const ORC: u8 = 0;
+                for i in test_vec1.len()..readbuf.len() {
+                    if ORC != readbuf[i] {
+                        tests_ok = false;
+                        led1.set_low();
+                    }
+                }
+            }
+        }
+        Err(_) => {
+            tests_ok = false;
+            led1.set_low();
+        }
+    }
+
+    // Wrap interface in embedded-hal-spy to access embedded_hal traits
+    let mut eh_spi = embedded_hal_spy::new(spi, |_| {});
+    use embedded_hal::blocking::spi::Write;
+    match eh_spi.write(reference_data) {
+        Ok(_) => {}
+        Err(_) => {
+            tests_ok = false;
+            led2.set_low()
+        }
+    }
+
+    let mut test_vec2 = *reference_data;
+    match eh_spi.transfer(&mut test_vec2) {
+        Ok(_) => {
+            for i in 0..test_vec2.len() {
+                if test_vec2[i] != reference_data[i] {
+                    tests_ok = false;
+                    led3.set_low();
+                }
+            }
+        }
+        Err(_) => {
+            tests_ok = false;
+            led4.set_low();
+        }
+    }
+
+    if tests_ok {
+        led1.set_low();
+        led2.set_low();
+        led3.set_low();
+        led4.set_low();
+    }
+
+    loop {}
+}

--- a/examples/spi-demo/src/main.rs
+++ b/examples/spi-demo/src/main.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
         miso: Some(spimiso),
         mosi: Some(spimosi),
     };
-    let mut spi = p.SPIM2.constrain(pins);
+    let mut spi = p.SPIM2.constrain(pins, nrf52832_hal::spim::Frequency::K500, nrf52832_hal::spim::MODE_0, 0 );
 
     let reference_data = b"Hello,echo Loopback";
     // Read only test vector


### PR DESCRIPTION
# spi-demo
SPIM demonstation code.
Connect a resistor between pin 22 and 23 on to feed MOSI direct back to MISO
If all tests Led1 to 4 will light up, in case of error only the failing test
case will light up.

## HW connections
Pin     Connecton   
P0.24   SPIclk
P0.23   MOSI
P0.22   MISO

This is designed for nRF52-DK board:
https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52-DK

This PR is based on #48 comments on main implementation should be tracked there. This should track the example implementation.