### PR TITLE
feat: add nrf52810

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,12 @@ addons:
     packages:
       - gcc-arm-none-eabi
 script:
-  - rustup target add thumbv7em-none-eabihf
+  - rustup target add thumbv7em-none-eabi thumbv7em-none-eabihf
+  - cargo build --manifest-path nrf52810-hal/Cargo.toml --target thumbv7em-none-eabi
   - cargo build --manifest-path nrf52832-hal/Cargo.toml
   - cargo build --manifest-path nrf52840-hal/Cargo.toml
   - cargo build --manifest-path boards/adafruit_nrf52pro/Cargo.toml --examples
   - cargo build --manifest-path boards/nRF52840-DK/Cargo.toml --examples
   - cargo build --manifest-path examples/rtfm-demo/Cargo.toml
+  - cargo build --manifest-path examples/rtfm-demo/Cargo.toml --no-default-features --features="52810" --target thumbv7em-none-eabi
   - cargo build --manifest-path examples/rtfm-demo/Cargo.toml --no-default-features --features="52840"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "boards/adafruit_nrf52pro",
   "boards/nRF52840-DK",
+  "nrf52810-hal",
   "nrf52832-hal",
   "nrf52840-hal",
   "examples/rtfm-demo",

--- a/examples/rtfm-demo/Cargo.toml
+++ b/examples/rtfm-demo/Cargo.toml
@@ -10,7 +10,7 @@ panic-semihosting = "0.5"
 cortex-m-semihosting = "0.3"
 
 [dependencies.nrf52810-hal]
-version = "0.1"
+version = "0.6"
 path = "../../nrf52810-hal"
 optional = true
 
@@ -25,7 +25,7 @@ path = "../../nrf52840-hal"
 optional = true
 
 [dependencies.nrf52810-pac]
-version = "0.1"
+version = "0.6.0"
 optional = true
 
 [dependencies.nrf52832-pac]

--- a/examples/rtfm-demo/Cargo.toml
+++ b/examples/rtfm-demo/Cargo.toml
@@ -9,6 +9,11 @@ cortex-m-rtfm = "0.4"
 panic-semihosting = "0.5"
 cortex-m-semihosting = "0.3"
 
+[dependencies.nrf52810-hal]
+version = "0.1"
+path = "../../nrf52810-hal"
+optional = true
+
 [dependencies.nrf52832-hal]
 version = "0.6"
 path = "../../nrf52832-hal"
@@ -17,6 +22,10 @@ optional = true
 [dependencies.nrf52840-hal]
 version = "0.6"
 path = "../../nrf52840-hal"
+optional = true
+
+[dependencies.nrf52810-pac]
+version = "0.1"
 optional = true
 
 [dependencies.nrf52832-pac]
@@ -28,6 +37,7 @@ version = "0.6"
 optional = true
 
 [features]
+52810 = ["nrf52810-hal", "nrf52810-pac"]
 52832 = ["nrf52832-hal", "nrf52832-pac"]
 52840 = ["nrf52840-hal", "nrf52840-pac"]
 default = ["52832"]

--- a/examples/rtfm-demo/src/main.rs
+++ b/examples/rtfm-demo/src/main.rs
@@ -7,6 +7,9 @@ use panic_semihosting;
 use cortex_m_semihosting::{debug, hprintln};
 use rtfm::app;
 
+#[cfg(feature = "52810")]
+use nrf52810_pac;
+
 #[cfg(feature = "52832")]
 use nrf52832_pac;
 
@@ -14,6 +17,7 @@ use nrf52832_pac;
 use nrf52840_pac;
 
 
+#[cfg_attr(feature="52810", app(device = nrf52810_pac))]
 #[cfg_attr(feature="52832", app(device = nrf52832_pac))]
 #[cfg_attr(feature="52840", app(device = nrf52840_pac))]
 const APP: () = {

--- a/nrf52-hal-common/Cargo.toml
+++ b/nrf52-hal-common/Cargo.toml
@@ -30,7 +30,7 @@ version = "0.2.2"
 
 [dependencies.nrf52810-pac]
 optional = true
-version = "0.1.1"
+version = "0.6.0"
 
 [dependencies.nrf52832-pac]
 optional = true

--- a/nrf52-hal-common/src/gpio.rs
+++ b/nrf52-hal-common/src/gpio.rs
@@ -64,10 +64,10 @@ pub struct Pin<MODE> {
     _mode: PhantomData<MODE>,
 }
 
-#[cfg(feature = "52832")]
 use crate::target::P0;
+
 #[cfg(feature = "52840")]
-use crate::target::{ P0, P1 };
+use crate::target::{ P1 };
 
 use crate::hal::digital::{OutputPin, StatefulOutputPin, InputPin};
 
@@ -76,7 +76,7 @@ impl<MODE> Pin<MODE> {
     pub fn into_floating_input(self) -> Pin<Input<Floating>> {
         unsafe {
             &(*{
-                #[cfg(feature = "52832")]
+                #[cfg(any(feature = "52810", feature = "52832"))]
                 { P0::ptr() }
                 #[cfg(feature = "52840")]
                 { if !self.port { P0::ptr() } else { P1::ptr() } }
@@ -100,7 +100,7 @@ impl<MODE> Pin<MODE> {
     pub fn into_pullup_input(self) -> Pin<Input<PullUp>> {
         unsafe {
             &(*{
-                #[cfg(feature = "52832")]
+                #[cfg(any(feature = "52810", feature = "52832"))]
                 { P0::ptr() }
                 #[cfg(feature = "52840")]
                 { if !self.port { P0::ptr() } else { P1::ptr() } }
@@ -124,7 +124,7 @@ impl<MODE> Pin<MODE> {
     pub fn into_pulldown_input(self) -> Pin<Input<PullDown>> {
         unsafe {
             &(*{
-                #[cfg(feature = "52832")]
+                #[cfg(any(feature = "52810", feature = "52832"))]
                 { P0::ptr() }
                 #[cfg(feature = "52840")]
                 { if !self.port { P0::ptr() } else { P1::ptr() } }
@@ -164,7 +164,7 @@ impl<MODE> Pin<MODE> {
 
         unsafe {
             &(*{
-                #[cfg(feature = "52832")]
+                #[cfg(any(feature = "52810", feature = "52832"))]
                 { P0::ptr() }
                 #[cfg(feature = "52840")]
                 { if !self.port { P0::ptr() } else { P1::ptr() } }
@@ -207,7 +207,7 @@ impl<MODE> Pin<MODE> {
         // register for this pin.
         let pin_cnf = unsafe {
             &(*{
-                #[cfg(feature = "52832")]
+                #[cfg(any(feature = "52810", feature = "52832"))]
                 { P0::ptr() }
                 #[cfg(feature = "52840")]
                 { if !self.port { P0::ptr() } else { P1::ptr() } }
@@ -234,7 +234,7 @@ impl<MODE> InputPin for Pin<Input<MODE>> {
     fn is_low(&self) -> bool {
         unsafe { (
             (*{
-                #[cfg(feature = "52832")]
+                #[cfg(any(feature = "52810", feature = "52832"))]
                 { P0::ptr() }
                 #[cfg(feature = "52840")]
                 { if !self.port { P0::ptr() } else { P1::ptr() } }
@@ -250,7 +250,7 @@ impl<MODE> OutputPin for Pin<Output<MODE>> {
         // TODO - I wish I could do something like `.pins$i()`...
         unsafe {
             (*{
-                #[cfg(feature = "52832")]
+                #[cfg(any(feature = "52810", feature = "52832"))]
                 { P0::ptr() }
                 #[cfg(feature = "52840")]
                 { if !self.port { P0::ptr() } else { P1::ptr() } }
@@ -264,7 +264,7 @@ impl<MODE> OutputPin for Pin<Output<MODE>> {
         // TODO - I wish I could do something like `.pins$i()`...
         unsafe {
             (*{
-                #[cfg(feature = "52832")]
+                #[cfg(any(feature = "52810", feature = "52832"))]
                 { P0::ptr() }
                 #[cfg(feature = "52840")]
                 { if !self.port { P0::ptr() } else { P1::ptr() } }
@@ -285,7 +285,7 @@ impl<MODE> StatefulOutputPin for Pin<Output<MODE>> {
         // TODO - I wish I could do something like `.pins$i()`...
         unsafe { (
             (*{
-                #[cfg(feature = "52832")]
+                #[cfg(any(feature = "52810", feature = "52832"))]
                 { P0::ptr() }
                 #[cfg(feature = "52840")]
                 { if !self.port { P0::ptr() } else { P1::ptr() } }

--- a/nrf52-hal-common/src/lib.rs
+++ b/nrf52-hal-common/src/lib.rs
@@ -2,6 +2,9 @@
 
 use embedded_hal as hal;
 
+#[cfg(feature = "52810")]
+pub use nrf52810_pac as target;
+
 #[cfg(feature = "52832")]
 pub use nrf52832_pac as target;
 
@@ -32,7 +35,7 @@ pub mod prelude {
 }
 
 /// Length of Nordic EasyDMA differs for MCUs
-#[cfg(feature = "52832")]
+#[cfg(any(feature = "52810", feature = "52832"))]
 pub mod target_constants {
     // NRF52832 8 bits1..0xFF
     pub const EASY_DMA_SIZE: usize = 255;

--- a/nrf52-hal-common/src/spim.rs
+++ b/nrf52-hal-common/src/spim.rs
@@ -5,12 +5,10 @@ use core::ops::Deref;
 use core::sync::atomic::{compiler_fence, Ordering::SeqCst};
 use core::cmp::min;
 
-use crate::target::{
-    spim0,
-    SPIM0,
-    SPIM1,
-    SPIM2,
-};
+use crate::target::{spim0, SPIM0};
+
+#[cfg(any(feature = "52832", feature = "52840"))]
+use crate::target::{SPIM1, SPIM2};
 
 use crate::target_constants::{EASY_DMA_SIZE,SRAM_LOWER,SRAM_UPPER,FORCE_COPY_BUFFER_SIZE};
 use crate::prelude::*;
@@ -38,12 +36,13 @@ macro_rules! impl_spim_ext {
     }
 }
 
+impl_spim_ext!(SPIM0,);
+
+#[cfg(any(feature = "52832", feature = "52840"))]
 impl_spim_ext!(
-    SPIM0,
     SPIM1,
     SPIM2,
 );
-
 
 /// Interface to a SPIM instance
 ///

--- a/nrf52-hal-common/src/timer.rs
+++ b/nrf52-hal-common/src/timer.rs
@@ -17,11 +17,11 @@ use crate::target::{
     TIMER0,
     TIMER1,
     TIMER2,
-    TIMER3,
-    TIMER4,
 };
 use void::{unreachable, Void};
 
+#[cfg(any(feature = "52832", feature = "52840"))]
+use crate::target::{TIMER3, TIMER4};
 
 pub trait TimerExt : Deref<Target=timer0::RegisterBlock> + Sized {
     // The interrupt that belongs to this timer instance
@@ -48,10 +48,13 @@ impl_timer_ext!(
     TIMER0,
     TIMER1,
     TIMER2,
+);
+
+#[cfg(any(feature = "52832", feature = "52840"))]
+impl_timer_ext!(
     TIMER3,
     TIMER4,
 );
-
 
 /// Interface to a TIMER instance
 ///

--- a/nrf52-hal-common/src/twim.rs
+++ b/nrf52-hal-common/src/twim.rs
@@ -11,8 +11,10 @@ use crate::target::{
     twim0,
     P0,
     TWIM0,
-    TWIM1,
 };
+
+#[cfg(any(feature = "52832", feature = "52840"))]
+use crate::target::TWIM1;
 
 use crate::gpio::{
     Pin,
@@ -43,11 +45,10 @@ macro_rules! impl_twim_ext {
     }
 }
 
-impl_twim_ext!(
-    TWIM0,
-    TWIM1,
-);
+impl_twim_ext!(TWIM0,);
 
+#[cfg(any(feature = "52832", feature = "52840"))]
+impl_twim_ext!(TWIM1,);
 
 /// Interface to a TWIM instance
 ///

--- a/nrf52810-hal/Cargo.toml
+++ b/nrf52810-hal/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "nrf52-hal-common"
-version = "0.6.1"
-description = "Common HAL for the nRF52 family of microcontrollers.  More specific HAL crates also exist."
-
+name = "nrf52810-hal"
+version = "0.1.0"
+edition = "2018"
+description = "HAL for nRF52810 microcontrollers"
 repository = "https://github.com/nrf-rs/nrf52-hal"
 authors = [
     "James Munns <james@onevariable.com>",
@@ -10,15 +10,14 @@ authors = [
     "John Scarrott <johnps@outlook.com>",
     "Wez Furlong <wez@wezfurlong.org>",
 ]
-
 categories = ["embedded", "hardware-support", "no-std"]
-keywords = ["arm", "cortex-m", "nrf52", "hal"]
+keywords = ["arm", "cortex-m", "nrf52", "hal", "nrf52810"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
 
 [dependencies]
 cortex-m = "0.5.8"
 nb = "0.1.1"
+nrf52810-pac = "0.1.1"
 
 [dependencies.void]
 default-features = false
@@ -28,17 +27,11 @@ version = "1.0.2"
 default-features = false
 version = "0.2.2"
 
-[dependencies.nrf52810-pac]
-optional = true
-version = "0.1.1"
-
-[dependencies.nrf52832-pac]
-optional = true
-version = "0.6.0"
-
-[dependencies.nrf52840-pac]
-optional = true
-version = "0.6.0"
+[dependencies.nrf52-hal-common]
+path = "../nrf52-hal-common"
+default-features = false
+features = ["52810"]
+version = "0.6.1"
 
 [dependencies.embedded-hal]
 features = ["unproven"]
@@ -46,8 +39,5 @@ version = "0.2.1"
 
 [features]
 doc = []
-default = ["52832"]
-52810 = ["nrf52810-pac"]
-52832 = ["nrf52832-pac"]
-52840 = ["nrf52840-pac"]
-
+rt = ["nrf52810-pac/rt"]
+default = ["rt"]

--- a/nrf52810-hal/Cargo.toml
+++ b/nrf52810-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52810-hal"
-version = "0.1.0"
+version = "0.6.0"
 edition = "2018"
 description = "HAL for nRF52810 microcontrollers"
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -9,6 +9,7 @@ authors = [
     "Hanno Braun <hanno@braun-robotics.com>",
     "John Scarrott <johnps@outlook.com>",
     "Wez Furlong <wez@wezfurlong.org>",
+    "Ferdia McKeogh <ferdia@mckeogh.tech",
 ]
 categories = ["embedded", "hardware-support", "no-std"]
 keywords = ["arm", "cortex-m", "nrf52", "hal", "nrf52810"]
@@ -17,7 +18,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 cortex-m = "0.5.8"
 nb = "0.1.1"
-nrf52810-pac = "0.1.1"
+nrf52810-pac = "0.6.0"
 
 [dependencies.void]
 default-features = false

--- a/nrf52810-hal/build.rs
+++ b/nrf52810-hal/build.rs
@@ -1,0 +1,17 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Put the linker script somewhere the linker can find it
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=memory.x");
+}

--- a/nrf52810-hal/memory.x
+++ b/nrf52810-hal/memory.x
@@ -1,0 +1,23 @@
+/* Linker script for the nRF52 - WITHOUT SOFT DEVICE */
+MEMORY
+{
+  /* NOTE K = KiBi = 1024 bytes */
+  FLASH : ORIGIN = 0x00000000, LENGTH = 192K
+  RAM : ORIGIN = 0x20000000, LENGTH = 24K
+}
+
+/* This is where the call stack will be allocated. */
+/* The stack is of the full descending type. */
+/* You may want to use this variable to locate the call stack and static
+   variables in different memory regions. Below is shown the default value */
+/* _stack_start = ORIGIN(RAM) + LENGTH(RAM); */
+
+/* You can use this symbol to customize the location of the .text section */
+/* If omitted the .text section will be placed right after the .vector_table
+   section */
+/* This is required only on microcontrollers that store some configuration right
+   after the vector table */
+/* _stext = ORIGIN(FLASH) + 0x400; */
+
+/* Size of the heap (in bytes) */
+/* _heap_size = 1024; */

--- a/nrf52810-hal/src/lib.rs
+++ b/nrf52810-hal/src/lib.rs
@@ -1,0 +1,23 @@
+#![no_std]
+
+use embedded_hal as hal;
+pub use nrf52810_pac;
+pub use nrf52_hal_common::*;
+
+pub mod prelude {
+    pub use crate::hal::prelude::*;
+    pub use nrf52_hal_common::prelude::*;
+
+    pub use crate::clocks::ClocksExt;
+    pub use crate::gpio::GpioExt;
+    pub use crate::spim::SpimExt;
+    pub use crate::time::U32Ext;
+    pub use crate::timer::TimerExt;
+    pub use crate::uarte::UarteExt;
+}
+
+pub use crate::clocks::Clocks;
+pub use crate::delay::Delay;
+pub use crate::spim::Spim;
+pub use crate::timer::Timer;
+pub use crate::uarte::Uarte;


### PR DESCRIPTION
This PR adds support for the nRF52810 microcontroller. Since it modifies the common crate, testing with all 3 microcontrollers in the series should be completed before it is merged.

I was unsure of what version to make the `nrf52810-pac` and `nrf52810-hal` crates, and if merged, transferring ownership of `nrf52810-pac` to the `nrf-rs` organisation should be done too.