### PR TITLE
Release version 0.7.0 of all HAL crates

### DIFF
--- a/boards/nRF52840-DK/Cargo.toml
+++ b/boards/nRF52840-DK/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 cortex-m = { version = "0.5.4", features = [ "const-fn" ] }
 cortex-m-rt = "0.6.5"
 embedded-hal = "0.2.1"
-nrf52840-hal = { version = "0.6.1", path = "../../nrf52840-hal" }
+nrf52840-hal = { version = "0.7.0", path = "../../nrf52840-hal" }
 
 [dev-dependencies]
 cortex-m-rt = "0.6.5"

--- a/examples/rtfm-demo/Cargo.toml
+++ b/examples/rtfm-demo/Cargo.toml
@@ -10,17 +10,17 @@ panic-semihosting = "0.5"
 cortex-m-semihosting = "0.3"
 
 [dependencies.nrf52810-hal]
-version = "0.6"
+version = "0.7"
 path = "../../nrf52810-hal"
 optional = true
 
 [dependencies.nrf52832-hal]
-version = "0.6"
+version = "0.7"
 path = "../../nrf52832-hal"
 optional = true
 
 [dependencies.nrf52840-hal]
-version = "0.6"
+version = "0.7"
 path = "../../nrf52840-hal"
 optional = true
 

--- a/nrf52-hal-common/Cargo.toml
+++ b/nrf52-hal-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52-hal-common"
-version = "0.6.1"
+version = "0.7.0"
 description = "Common HAL for the nRF52 family of microcontrollers.  More specific HAL crates also exist."
 
 repository = "https://github.com/nrf-rs/nrf52-hal"

--- a/nrf52810-hal/Cargo.toml
+++ b/nrf52810-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52810-hal"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2018"
 description = "HAL for nRF52810 microcontrollers"
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -32,7 +32,7 @@ version = "0.2.2"
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52810"]
-version = "0.6.1"
+version = "0.7.0"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52832-hal/Cargo.toml
+++ b/nrf52832-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52832-hal"
-version = "0.6.1"
+version = "0.7.0"
 description = "HAL for nRF52832 microcontrollers"
 
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -31,7 +31,7 @@ version = "0.2.2"
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52832"]
-version = "0.6.1"
+version = "0.7.0"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52840-hal"
-version = "0.6.1"
+version = "0.7.0"
 description = "HAL for nRF52840 microcontrollers"
 
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -33,7 +33,7 @@ version = "0.2.2"
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52840"]
-version = "0.6.1"
+version = "0.7.0"
 
 [dependencies.embedded-hal]
 features = ["unproven"]


### PR DESCRIPTION
I'd like to publish new crates.io versions of all HAL crates. Or more specifically, I'd like to publish version 0.7.0 of `nrf52832-hal`, as that's blocking my progress downstream, but releasing all the others as well seem like the right thing to do.

I know that there is some [ongoing controvery](https://github.com/nrf-rs/nrf52-hal/issues/37), as well as some open pull requests. I'd still like to get this out now, as there have been many improvements (some of which I need to publish my [`dwm1001` crate](https://github.com/braun-robotics/rust-dwm1001)). If more things get merged soon, we can publish more versions as required.

Anyone opposed to doing this release right now?

cc @nrf-rs/nrf52 