### PR TITLE
Implement rand::RngCore for Rng

### DIFF
--- a/nrf52-hal-common/Cargo.toml
+++ b/nrf52-hal-common/Cargo.toml
@@ -19,7 +19,10 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.5.8"
 nb = "0.1.1"
-rand = { version = "0.6.5", default-features = false }
+
+[dependencies.rand]
+default-features = false
+version = "0.6.5"
 
 [dependencies.void]
 default-features = false

--- a/nrf52-hal-common/Cargo.toml
+++ b/nrf52-hal-common/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.5.8"
 nb = "0.1.1"
+rand = { version = "0.6.5", default-features = false }
 
 [dependencies.void]
 default-features = false
@@ -50,4 +51,3 @@ default = ["52832"]
 52810 = ["nrf52810-pac"]
 52832 = ["nrf52832-pac"]
 52840 = ["nrf52840-pac"]
-

--- a/nrf52-hal-common/src/rng.rs
+++ b/nrf52-hal-common/src/rng.rs
@@ -4,6 +4,7 @@
 
 
 use core::ops::Deref;
+use rand::RngCore;
 
 use crate::target::{
     rng,
@@ -82,5 +83,23 @@ impl Rng {
             (buf[5] as u64) << 40 |
             (buf[6] as u64) << 48 |
             (buf[7] as u64) << 56
+    }
+}
+
+impl RngCore for Rng {
+    fn next_u32(&mut self) -> u32 {
+        self.random_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.random_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.random(dest)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        Ok(self.fill_bytes(dest))
     }
 }


### PR DESCRIPTION
This PR implements rand's `RngCore` trait for `Rng`. This will not have an additional cost for those depending on the HAL, but does allow generic drivers and libraries. The embedded-hal `rng::Read` trait is not final and is currently feature-gated, while `RngCore` has more widespread adoption.