### PR TITLE
fix: switch to rand_core and mark `Rng` with `CryptoRng`

### DIFF
--- a/nrf52-hal-common/Cargo.toml
+++ b/nrf52-hal-common/Cargo.toml
@@ -20,10 +20,7 @@ edition = "2018"
 cortex-m = "0.5.8"
 nb = "0.1.1"
 fpa = "0.1.0"
-
-[dependencies.rand]
-default-features = false
-version = "0.6.5"
+rand_core = "0.4.0"
 
 [dependencies.void]
 default-features = false

--- a/nrf52-hal-common/src/rng.rs
+++ b/nrf52-hal-common/src/rng.rs
@@ -4,7 +4,7 @@
 
 
 use core::ops::Deref;
-use rand::RngCore;
+use rand_core::{CryptoRng, RngCore};
 
 use crate::target::{
     rng,
@@ -99,7 +99,9 @@ impl RngCore for Rng {
         self.random(dest)
     }
 
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
         Ok(self.fill_bytes(dest))
     }
 }
+
+impl CryptoRng for Rng {}


### PR DESCRIPTION
Follow up to https://github.com/nrf-rs/nrf52-hal/pull/69; I should've used `rand_core` and not `rand` as it pulls in unneeded code, from the docs: "This crate is mainly of interest to crates publishing implementations of RngCore".

This PR fixes that, and additionally uses the `CryptoRng` marker trait to indicate that the RNG is safe to use for cryptographic purposes (as described in the data sheets).