### PR TITLE
Add embedded_hal::blocking::i2c trait implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,7 @@ script:
   - cargo build --manifest-path examples/rtfm-demo/Cargo.toml --no-default-features --features="52810" --target thumbv7em-none-eabi
   - cargo build --manifest-path examples/rtfm-demo/Cargo.toml --no-default-features --features="52840"
   - cargo build --manifest-path examples/spi-demo/Cargo.toml
+  - cargo build --manifest-path examples/twi-ssd1306/Cargo.toml
+  - cargo build --manifest-path examples/twi-ssd1306/Cargo.toml --no-default-features --features="52840" --target thumbv7em-none-eabi
+
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "nrf52840-hal",
   "examples/rtfm-demo",
   "examples/spi-demo",
+  "examples/twi-ssd1306",
 ]
 
 [profile.dev]
@@ -19,3 +20,4 @@ lto = false
 debug = true
 lto = true
 opt-level = "s"
+

--- a/examples/twi-ssd1306/.cargo/config
+++ b/examples/twi-ssd1306/.cargo/config
@@ -1,0 +1,2 @@
+[target.thumbv7em-none-eabihf]
+runner = "arm-none-eabi-gdb -tui"

--- a/examples/twi-ssd1306/.gdbinit
+++ b/examples/twi-ssd1306/.gdbinit
@@ -1,0 +1,10 @@
+set remotetimeout 60000
+target remote :2331
+set arm force-mode thumb
+
+# Uncomment to enable semihosting, when necessary
+monitor semihosting enable
+
+layout split
+monitor reset
+load

--- a/examples/twi-ssd1306/Cargo.toml
+++ b/examples/twi-ssd1306/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "twi-ssd1306"
+version = "0.1.0"
+authors = ["James Waples <james@wapl.es>", "Ruben Paz <me@ruben.io>"]
+edition = "2018"
+
+[dependencies]
+cortex-m-rt = "0.6.5"
+ssd1306 = "0.2.4"
+embedded-graphics = "0.4.7"
+panic-semihosting = "0.5.1"
+
+[dependencies.embedded-hal]
+features = ["unproven"]
+version = "0.2"
+
+[dependencies.nrf52832-hal]
+version = "0.7.0"
+path = "../../nrf52832-hal"
+optional = true
+
+[dependencies.nrf52840-hal]
+version = "0.7.0"
+path = "../../nrf52840-hal"
+optional = true
+
+[features]
+52832 = ["nrf52832-hal"]
+52840 = ["nrf52840-hal"]
+default = ["52832"]

--- a/examples/twi-ssd1306/README.md
+++ b/examples/twi-ssd1306/README.md
@@ -1,0 +1,18 @@
+# TWI-SSD1306 
+
+TWI write example using an SSD1306 OLED display:
+https://cdn-shop.adafruit.com/datasheets/SSD1306.pdf
+
+After running it you should see the words "Hello Rust!" on the display.
+
+## HW connections
+Pin     Connecton
+P0.26   SCL
+P0.27   SDA
+
+This is designed for the nRF52-DK & the nRF52840-DK board:
+https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52-DK
+https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK
+
+The TWI device is a 128x64px SSD1306
+https://cdn-shop.adafruit.com/datasheets/SSD1306.pdf

--- a/examples/twi-ssd1306/src/main.rs
+++ b/examples/twi-ssd1306/src/main.rs
@@ -1,0 +1,63 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_semihosting;
+
+use cortex_m_rt::entry;
+
+use embedded_graphics::fonts::Font6x8;
+use embedded_graphics::prelude::*;
+use ssd1306::prelude::*;
+use ssd1306::Builder;
+
+#[cfg(feature = "52832")]
+use nrf52832_hal::{
+    nrf52832_pac as pac,
+    gpio::*,
+    twim,
+    prelude::TwimExt,
+};
+
+#[cfg(feature = "52840")]
+use nrf52840_hal::{
+    nrf52840_pac as pac,
+    gpio::*,
+    twim,
+    prelude::TwimExt,
+};
+
+
+/// TWI write example code using an SSD1306 OLED display:
+/// https://cdn-shop.adafruit.com/datasheets/SSD1306.pdf
+///
+/// Connect SDA to P0.27 and SCL to pin P0.26
+///
+/// You should see the words "Hello Rust!" on the display.
+#[entry]
+fn main() -> ! {
+    let p = pac::Peripherals::take().unwrap();
+    let port0 = p.P0.split();
+
+    let scl = port0.p0_26.into_floating_input().degrade();
+    let sda = port0.p0_27.into_floating_input().degrade();
+
+    let pins = twim::Pins { scl, sda };
+
+    let i2c = p.TWIM0.constrain(pins, twim::Frequency::K100);
+
+    let mut disp: GraphicsMode<_> = Builder::new().connect_i2c(i2c).into();
+
+    disp.init().expect("Display initialization");
+    disp.flush().expect("Cleans the display");
+
+    disp.draw(
+        Font6x8::render_str("Hello Rust!")
+            .with_stroke(Some(1u8.into()))
+            .translate(Coord::new(10, 24))
+            .into_iter(),
+    );
+
+    disp.flush().expect("Render display");
+
+    loop {}
+}

--- a/nrf52-hal-common/src/twim.rs
+++ b/nrf52-hal-common/src/twim.rs
@@ -372,6 +372,31 @@ impl<T> Twim<T> where T: TwimExt {
     }
 }
 
+/// Implementation of embedded_hal::blocking::i2c Traits
+
+impl<T> embedded_hal::blocking::i2c::Write for Twim<T> where T: TwimExt {
+    type Error = Error;
+
+    fn write<'w>(&mut self, addr: u8, bytes: &'w [u8]) -> Result<(), Error> {
+        self.write(addr, bytes)
+    }
+}
+
+impl<T> embedded_hal::blocking::i2c::Read for Twim<T> where T: TwimExt {
+    type Error = Error;
+
+    fn read<'w>(&mut self, addr: u8, bytes: &'w mut [u8]) -> Result<(), Error> {
+        self.read(addr, bytes)
+    }
+}
+
+impl<T> embedded_hal::blocking::i2c::WriteRead for Twim<T> where T: TwimExt {
+    type Error = Error;
+
+    fn write_read<'w>(&mut self, addr: u8, bytes:&'w[u8], buffer: &'w mut [u8]) -> Result<(), Error> {
+        self.write_then_read(addr, bytes, buffer)
+    }
+}
 
 /// The pins used by the TWIN peripheral
 ///


### PR DESCRIPTION
I was trying to use the Twin strut with other crates that use the i2c traits defined in embedded_hal (embedded_graphics) and I found that Twin was not implementing such traits.

This PR adds the trait implementations linking the logic to the existing functions in the default implementation of th eTwin strut. I didn't move the code to the trait implementation because I was not sure if it would break existing code, but I think this would be the right thing to do.

This PR also adds a new example using the TWI peripheral to use an I2C device. The example only uses the write mechanism.

I would like to add more examples using I2C but I do not have any devices I can use to test atm.

If choose to accept this PR, I would like to clarify if the current implementation of the traits is the right approach. Any other feedback or changes are welcome.