### PR TITLE
SAADC Implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,3 @@ script:
   - cargo build --manifest-path examples/spi-demo/Cargo.toml
   - cargo build --manifest-path examples/twi-ssd1306/Cargo.toml
   - cargo build --manifest-path examples/twi-ssd1306/Cargo.toml --no-default-features --features="52840" --target thumbv7em-none-eabi
-
-

--- a/nrf52-hal-common/src/lib.rs
+++ b/nrf52-hal-common/src/lib.rs
@@ -34,6 +34,7 @@ pub mod prelude {
     pub use crate::timer::TimerExt;
     pub use crate::twim::TwimExt;
     pub use crate::uarte::UarteExt;
+    pub use crate::saadc::SaadcExt;
 }
 
 /// Length of Nordic EasyDMA differs for MCUs

--- a/nrf52-hal-common/src/lib.rs
+++ b/nrf52-hal-common/src/lib.rs
@@ -21,6 +21,7 @@ pub mod timer;
 pub mod twim;
 pub mod uarte;
 pub mod temp;
+pub mod saadc;
 
 pub mod prelude {
     pub use crate::hal::prelude::*;
@@ -61,3 +62,4 @@ pub use crate::spim::Spim;
 pub use crate::timer::Timer;
 pub use crate::twim::Twim;
 pub use crate::uarte::Uarte;
+pub use crate::saadc::Saadc;

--- a/nrf52-hal-common/src/saadc.rs
+++ b/nrf52-hal-common/src/saadc.rs
@@ -1,0 +1,82 @@
+//use crate::gpio::{Floating, Input, Pin};
+use crate::gpio::{Floating, Input};
+use crate::target::{saadc, SAADC};
+use core::ops::Deref;
+use embedded_hal::adc::{Channel, OneShot};
+
+// Only 1 channel is allowed right now, a discussion needs to be had as to how
+// multiple channels should work (See SCAN_MODE)
+
+pub trait SaadcExt: Deref<Target = saadc::RegisterBlock> + Sized {
+    fn constrain(self) -> Saadc;
+}
+
+impl Channel<Saadc> for crate::gpio::p0::P0_02<Input<Floating>> {
+    type ID = u8;
+
+    fn channel() -> <Self as embedded_hal::adc::Channel<Saadc>>::ID {
+        0u8
+    }
+}
+
+pub struct Saadc(SAADC);
+
+impl Saadc {
+    pub fn new(saadc: SAADC) -> Self {
+        saadc.enable.write(|w| w.enable().enabled());
+        saadc.resolution.write(|w| w.val()._12bit());
+        saadc.oversample.write(|w| w.oversample().bypass());
+        saadc.samplerate.write(|w| w.mode().task());
+
+        saadc.ch[0].config.write(|w| {
+            w.refsel()
+                .internal()
+                .gain()
+                .gain1_6()
+                .tacq()
+                ._20us()
+                .mode()
+                .se()
+                .resp()
+                .bypass()
+                .resn()
+                .bypass()
+                .burst()
+                .enabled()
+        });
+        saadc.ch[0].pselp.write(|w| w.pselp().analog_input0());
+        saadc.ch[0].pseln.write(|w| w.pseln().nc());
+
+        // Calibrate
+        saadc.tasks_calibrateoffset.write(|w| unsafe { w.bits(1) });
+        while saadc.events_calibratedone.read().bits() == 0 {}
+
+        Saadc(saadc)
+    }
+}
+
+impl<PIN> OneShot<Saadc, u16, PIN> for Saadc
+where
+    PIN: Channel<Saadc, ID = u8>,
+{
+    type Error = ();
+    fn read(&mut self, _pin: &mut PIN) -> nb::Result<u16, Self::Error> {
+        let mut val = 0u16;
+        self.0
+            .result
+            .ptr
+            .write(|w| unsafe { w.ptr().bits(((&mut val) as *mut _) as u32) });
+        self.0
+            .result
+            .maxcnt
+            .write(|w| unsafe { w.maxcnt().bits(1) });
+
+        self.0.tasks_start.write(|w| unsafe { w.bits(1) });
+        self.0.tasks_sample.write(|w| unsafe { w.bits(1) });
+
+        while self.0.events_end.read().bits() == 0 {}
+        self.0.events_end.reset();
+
+        Ok(val)
+    }
+}

--- a/nrf52-hal-common/src/saadc.rs
+++ b/nrf52-hal-common/src/saadc.rs
@@ -36,7 +36,6 @@ impl Saadc {
                 .burst()
                 .enabled()
         });
-        saadc.ch[0].pselp.write(|w| w.pselp().analog_input0());
         saadc.ch[0].pseln.write(|w| w.pseln().nc());
 
         // Calibrate
@@ -52,7 +51,20 @@ where
     PIN: Channel<Saadc, ID = u8>,
 {
     type Error = ();
-    fn read(&mut self, _pin: &mut PIN) -> nb::Result<u16, Self::Error> {
+    fn read(&mut self, pin: &mut PIN) -> nb::Result<u16, Self::Error> {
+        match PIN::channel() {
+            0 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input0()),
+            1 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input1()),
+            2 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input2()),
+            3 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input3()),
+            4 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input4()),
+            5 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input5()),
+            6 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input6()),
+            7 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input7()),
+            // This can never happen as if another pin was used, there would be a compile time error
+            _ => panic!("Invalid pin"),
+        }
+
         let mut val = 0u16;
         self.0
             .result

--- a/nrf52-hal-common/src/saadc.rs
+++ b/nrf52-hal-common/src/saadc.rs
@@ -11,14 +11,6 @@ pub trait SaadcExt: Deref<Target = saadc::RegisterBlock> + Sized {
     fn constrain(self) -> Saadc;
 }
 
-impl Channel<Saadc> for crate::gpio::p0::P0_02<Input<Floating>> {
-    type ID = u8;
-
-    fn channel() -> <Self as embedded_hal::adc::Channel<Saadc>>::ID {
-        0u8
-    }
-}
-
 pub struct Saadc(SAADC);
 
 impl Saadc {
@@ -79,4 +71,29 @@ where
 
         Ok(val)
     }
+}
+
+macro_rules! channel_mappings {
+    ($($n:expr => $pin:path),*) => {
+        $(
+            impl Channel<Saadc> for $pin {
+                type ID = u8;
+
+                fn channel() -> <Self as embedded_hal::adc::Channel<Saadc>>::ID {
+                    $n
+                }
+            }
+        )*
+    };
+}
+
+channel_mappings! {
+    0 => crate::gpio::p0::P0_02<Input<Floating>>,
+    1 => crate::gpio::p0::P0_03<Input<Floating>>,
+    2 => crate::gpio::p0::P0_04<Input<Floating>>,
+    3 => crate::gpio::p0::P0_05<Input<Floating>>,
+    4 => crate::gpio::p0::P0_28<Input<Floating>>,
+    5 => crate::gpio::p0::P0_29<Input<Floating>>,
+    6 => crate::gpio::p0::P0_30<Input<Floating>>,
+    7 => crate::gpio::p0::P0_31<Input<Floating>>
 }

--- a/nrf52-hal-common/src/saadc.rs
+++ b/nrf52-hal-common/src/saadc.rs
@@ -9,6 +9,12 @@ use core::{
 };
 use embedded_hal::adc::{Channel, OneShot};
 
+pub use crate::target::saadc::{
+    ch::config::{GAINW as Gain, REFSELW as Reference, RESPW as Resistor, TACQW as Time},
+    oversample::OVERSAMPLEW as Oversample,
+    resolution::VALW as Resolution,
+};
+
 // Only 1 channel is allowed right now, a discussion needs to be had as to how
 // multiple channels should work (See "scan mode" in the datasheet)
 // Issue: https://github.com/nrf-rs/nrf52-hal/issues/82
@@ -19,30 +25,45 @@ pub trait SaadcExt: Deref<Target = saadc::RegisterBlock> + Sized {
 
 impl SaadcExt for SAADC {
     fn constrain(self) -> Saadc {
-        Saadc::new(self)
+        Saadc::new(self, SaadcConfig::default())
     }
 }
 
 pub struct Saadc(SAADC);
 
 impl Saadc {
-    pub fn new(saadc: SAADC) -> Self {
+    pub fn new(saadc: SAADC, config: SaadcConfig) -> Self {
+        // The write enums do not implement clone/copy/debug, only the
+        // read ones, hence the need to pull out and move the values
+        let SaadcConfig {
+            resolution,
+            oversample,
+            reference,
+            gain,
+            resistor,
+            time
+        } = config;
+
         saadc.enable.write(|w| w.enable().enabled());
-        saadc.resolution.write(|w| w.val()._12bit());
-        saadc.oversample.write(|w| w.oversample().bypass());
+        saadc
+            .resolution
+            .write(|w| w.val().variant(resolution));
+        saadc
+            .oversample
+            .write(|w| w.oversample().variant(oversample));
         saadc.samplerate.write(|w| w.mode().task());
 
         saadc.ch[0].config.write(|w| {
             w.refsel()
-                .internal()
+                .variant(reference)
                 .gain()
-                .gain1_6()
+                .variant(gain)
                 .tacq()
-                ._20us()
+                .variant(time)
                 .mode()
                 .se()
                 .resp()
-                .bypass()
+                .variant(resistor)
                 .resn()
                 .bypass()
                 .burst()
@@ -55,6 +76,29 @@ impl Saadc {
         while saadc.events_calibratedone.read().bits() == 0 {}
 
         Saadc(saadc)
+    }
+}
+
+pub struct SaadcConfig {
+    resolution: Resolution,
+    oversample: Oversample,
+    reference: Reference,
+    gain: Gain,
+    resistor: Resistor,
+    time: Time,
+}
+
+// 0 volts reads as 0, VDD volts reads as u16::MAX
+impl Default for SaadcConfig {
+    fn default() -> Self {
+        SaadcConfig {
+            resolution: Resolution::_14BIT,
+            oversample: Oversample::OVER8X,
+            reference: Reference::VDD1_4,
+            gain: Gain::GAIN1_4,
+            resistor: Resistor::BYPASS,
+            time: Time::_20US,
+        }
     }
 }
 
@@ -75,7 +119,7 @@ where
             7 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input7()),
             // This can never happen the only analog pins have already been defined
             // PAY CLOSE ATTENTION TO ANY CHANGES TO THIS IMPL OR THE `channel_mappings!` MACRO
-            _ => unsafe { unreachable_unchecked() }
+            _ => unsafe { unreachable_unchecked() },
         }
 
         let mut val: u16 = 0;

--- a/nrf52-hal-common/src/saadc.rs
+++ b/nrf52-hal-common/src/saadc.rs
@@ -3,6 +3,7 @@ use crate::{
     target::{saadc, SAADC},
 };
 use core::{
+    hint::unreachable_unchecked,
     ops::Deref,
     sync::atomic::{compiler_fence, Ordering::SeqCst},
 };
@@ -72,10 +73,9 @@ where
             5 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input5()),
             6 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input6()),
             7 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input7()),
-            // This can never happen as if another pin was used, there would be a compile time error
-            _ => {
-                return Err(nb::Error::Other(()));
-            }
+            // This can never happen the only analog pins have already been defined
+            // PAY CLOSE ATTENTION TO ANY CHANGES TO THIS IMPL OR THE `channel_mappings!` MACRO
+            _ => unsafe { unreachable_unchecked() }
         }
 
         let mut val: u16 = 0;

--- a/nrf52810-hal/src/lib.rs
+++ b/nrf52810-hal/src/lib.rs
@@ -18,6 +18,7 @@ pub mod prelude {
 
 pub use crate::clocks::Clocks;
 pub use crate::delay::Delay;
+pub use crate::saadc::Saadc;
 pub use crate::spim::Spim;
 pub use crate::timer::Timer;
 pub use crate::uarte::Uarte;

--- a/nrf52810-hal/src/lib.rs
+++ b/nrf52810-hal/src/lib.rs
@@ -14,6 +14,7 @@ pub mod prelude {
     pub use crate::time::U32Ext;
     pub use crate::timer::TimerExt;
     pub use crate::uarte::UarteExt;
+    pub use crate::saadc::SaadcExt;
 }
 
 pub use crate::clocks::Clocks;

--- a/nrf52832-hal/src/lib.rs
+++ b/nrf52832-hal/src/lib.rs
@@ -18,6 +18,7 @@ pub mod prelude {
 
 pub use crate::clocks::Clocks;
 pub use crate::delay::Delay;
+pub use crate::saadc::Saadc;
 pub use crate::spim::Spim;
 pub use crate::timer::Timer;
 pub use crate::uarte::Uarte;

--- a/nrf52832-hal/src/lib.rs
+++ b/nrf52832-hal/src/lib.rs
@@ -14,6 +14,7 @@ pub mod prelude {
     pub use crate::time::U32Ext;
     pub use crate::timer::TimerExt;
     pub use crate::uarte::UarteExt;
+    pub use crate::saadc::SaadcExt;
 }
 
 pub use crate::clocks::Clocks;

--- a/nrf52840-hal/src/lib.rs
+++ b/nrf52840-hal/src/lib.rs
@@ -18,6 +18,7 @@ pub mod prelude {
 
 pub use crate::clocks::Clocks;
 pub use crate::delay::Delay;
+pub use crate::saadc::Saadc;
 pub use crate::spim::Spim;
 pub use crate::timer::Timer;
 pub use crate::uarte::Uarte;

--- a/nrf52840-hal/src/lib.rs
+++ b/nrf52840-hal/src/lib.rs
@@ -14,6 +14,7 @@ pub mod prelude {
     pub use crate::time::U32Ext;
     pub use crate::timer::TimerExt;
     pub use crate::uarte::UarteExt;
+    pub use crate::saadc::SaadcExt;
 }
 
 pub use crate::clocks::Clocks;


### PR DESCRIPTION
Initial PR for my SAADC work, there are still a few things I need some advice/input on.

- Reading VDD (Probably make a unit struct and implement channel for it)
- Configuration is currently hardcoded with reasonable values, how should this be configured?
- Only a single channel is utilised, and only one AIN can be read at a time, how should multiple be used? What about configurations for multiple values? How will values be returned when the sample task ends?
- Calibration is probably not implemented correctly, make it optional when all the channels are known at creation?
- Abuse of the `Channel` trait, any analog input can be connected to any channel's negative or positive side, this isn't well reflected in the current implementation

Squashing all the commits might also be a good idea, I made too many small changes.