### PR TITLE
Remove redundant pub use statements from nrf52832_hal::prelude.

### DIFF
--- a/nrf52832-hal/src/lib.rs
+++ b/nrf52832-hal/src/lib.rs
@@ -7,20 +7,13 @@ pub use nrf52_hal_common::*;
 pub mod prelude {
     pub use crate::hal::prelude::*;
     pub use nrf52_hal_common::prelude::*;
-
-    pub use crate::clocks::ClocksExt;
-    pub use crate::gpio::GpioExt;
-    pub use crate::spim::SpimExt;
-    pub use crate::time::U32Ext;
-    pub use crate::timer::TimerExt;
-    pub use crate::uarte::UarteExt;
-    pub use crate::saadc::SaadcExt;
 }
 
 pub use crate::clocks::Clocks;
 pub use crate::delay::Delay;
+pub use crate::rtc::Rtc;
 pub use crate::saadc::Saadc;
 pub use crate::spim::Spim;
+pub use crate::temp::Temp;
 pub use crate::timer::Timer;
 pub use crate::uarte::Uarte;
-pub use crate::temp::Temp;


### PR DESCRIPTION
These statements were coming in from `pub use nrf52_hal_common::prelude::*` anyway, so this is just cutting down some code duplication.