### PR TITLE
Commit with pre-release

### DIFF
--- a/boards/nRF52-DK/Cargo.toml
+++ b/boards/nRF52-DK/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 cortex-m = "0.5.8"
 cortex-m-rt = "0.6.7"
 panic-halt = "0.2.0"
-nrf52832-hal = { version = "0.7.0", path = "../../nrf52832-hal" }
+nrf52832-hal = { version = "0.8.0-beta1", path = "../../nrf52832-hal" }
 
 [dev-dependencies]
 nb = "0.1.1"

--- a/boards/nRF52-DK/Cargo.toml
+++ b/boards/nRF52-DK/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 cortex-m = "0.5.8"
 cortex-m-rt = "0.6.7"
 panic-halt = "0.2.0"
-nrf52832-hal = { version = "0.8.0-beta1", path = "../../nrf52832-hal" }
+nrf52832-hal = { version = "0.8.0", path = "../../nrf52832-hal" }
 
 [dev-dependencies]
 nb = "0.1.1"

--- a/boards/nRF52840-DK/Cargo.toml
+++ b/boards/nRF52840-DK/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 cortex-m = { version = "0.5.4", features = [ "const-fn" ] }
 cortex-m-rt = "0.6.5"
 embedded-hal = "0.2.1"
-nrf52840-hal = { version = "0.7.0", path = "../../nrf52840-hal" }
+nrf52840-hal = { version = "0.8.0-beta1", path = "../../nrf52840-hal" }
 
 [dev-dependencies]
 cortex-m-rt = "0.6.5"

--- a/boards/nRF52840-DK/Cargo.toml
+++ b/boards/nRF52840-DK/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 cortex-m = { version = "0.5.4", features = [ "const-fn" ] }
 cortex-m-rt = "0.6.5"
 embedded-hal = "0.2.1"
-nrf52840-hal = { version = "0.8.0-beta1", path = "../../nrf52840-hal" }
+nrf52840-hal = { version = "0.8.0", path = "../../nrf52840-hal" }
 
 [dev-dependencies]
 cortex-m-rt = "0.6.5"

--- a/examples/rtfm-demo/Cargo.toml
+++ b/examples/rtfm-demo/Cargo.toml
@@ -10,17 +10,17 @@ panic-semihosting = "0.5"
 cortex-m-semihosting = "0.3"
 
 [dependencies.nrf52810-hal]
-version = "0.8.0-beta1"
+version = "0.8.0"
 path = "../../nrf52810-hal"
 optional = true
 
 [dependencies.nrf52832-hal]
-version = "0.8.0-beta1"
+version = "0.8.0"
 path = "../../nrf52832-hal"
 optional = true
 
 [dependencies.nrf52840-hal]
-version = "0.8.0-beta1"
+version = "0.8.0"
 path = "../../nrf52840-hal"
 optional = true
 

--- a/examples/rtfm-demo/Cargo.toml
+++ b/examples/rtfm-demo/Cargo.toml
@@ -10,17 +10,17 @@ panic-semihosting = "0.5"
 cortex-m-semihosting = "0.3"
 
 [dependencies.nrf52810-hal]
-version = "0.7"
+version = "0.8.0-beta1"
 path = "../../nrf52810-hal"
 optional = true
 
 [dependencies.nrf52832-hal]
-version = "0.7"
+version = "0.8.0-beta1"
 path = "../../nrf52832-hal"
 optional = true
 
 [dependencies.nrf52840-hal]
-version = "0.7"
+version = "0.8.0-beta1"
 path = "../../nrf52840-hal"
 optional = true
 

--- a/examples/spi-demo/Cargo.toml
+++ b/examples/spi-demo/Cargo.toml
@@ -14,7 +14,7 @@ features = ["unproven"]
 version = "0.2"
 
 [dependencies.nrf52832-hal]
-version = "0.7.0"
+version = "0.8.0-beta1"
 path = "../../nrf52832-hal"
 optional = true
 

--- a/examples/spi-demo/Cargo.toml
+++ b/examples/spi-demo/Cargo.toml
@@ -14,7 +14,7 @@ features = ["unproven"]
 version = "0.2"
 
 [dependencies.nrf52832-hal]
-version = "0.8.0-beta1"
+version = "0.8.0"
 path = "../../nrf52832-hal"
 optional = true
 

--- a/examples/twi-ssd1306/Cargo.toml
+++ b/examples/twi-ssd1306/Cargo.toml
@@ -15,12 +15,12 @@ features = ["unproven"]
 version = "0.2"
 
 [dependencies.nrf52832-hal]
-version = "0.8.0-beta1"
+version = "0.8.0"
 path = "../../nrf52832-hal"
 optional = true
 
 [dependencies.nrf52840-hal]
-version = "0.8.0-beta1"
+version = "0.8.0"
 path = "../../nrf52840-hal"
 optional = true
 

--- a/examples/twi-ssd1306/Cargo.toml
+++ b/examples/twi-ssd1306/Cargo.toml
@@ -15,12 +15,12 @@ features = ["unproven"]
 version = "0.2"
 
 [dependencies.nrf52832-hal]
-version = "0.7.0"
+version = "0.8.0-beta1"
 path = "../../nrf52832-hal"
 optional = true
 
 [dependencies.nrf52840-hal]
-version = "0.7.0"
+version = "0.8.0-beta1"
 path = "../../nrf52840-hal"
 optional = true
 

--- a/nrf52-hal-common/Cargo.toml
+++ b/nrf52-hal-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52-hal-common"
-version = "0.8.0-beta1"
+version = "0.8.0"
 description = "Common HAL for the nRF52 family of microcontrollers.  More specific HAL crates also exist."
 
 repository = "https://github.com/nrf-rs/nrf52-hal"

--- a/nrf52-hal-common/Cargo.toml
+++ b/nrf52-hal-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52-hal-common"
-version = "0.7.0"
+version = "0.8.0-beta1"
 description = "Common HAL for the nRF52 family of microcontrollers.  More specific HAL crates also exist."
 
 repository = "https://github.com/nrf-rs/nrf52-hal"

--- a/nrf52810-hal/Cargo.toml
+++ b/nrf52810-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52810-hal"
-version = "0.7.0"
+version = "0.8.0-beta1"
 edition = "2018"
 description = "HAL for nRF52810 microcontrollers"
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -32,7 +32,7 @@ version = "0.2.2"
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52810"]
-version = "0.7.0"
+version = "0.8.0-beta1"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52810-hal/Cargo.toml
+++ b/nrf52810-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52810-hal"
-version = "0.8.0-beta1"
+version = "0.8.0"
 edition = "2018"
 description = "HAL for nRF52810 microcontrollers"
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -32,7 +32,7 @@ version = "0.2.2"
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52810"]
-version = "0.8.0-beta1"
+version = "0.8.0"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52832-hal/Cargo.toml
+++ b/nrf52832-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52832-hal"
-version = "0.7.0"
+version = "0.8.0-beta1"
 description = "HAL for nRF52832 microcontrollers"
 
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -31,7 +31,7 @@ version = "0.2.2"
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52832"]
-version = "0.7.0"
+version = "0.8.0-beta1"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52832-hal/Cargo.toml
+++ b/nrf52832-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52832-hal"
-version = "0.8.0-beta1"
+version = "0.8.0"
 description = "HAL for nRF52832 microcontrollers"
 
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -31,7 +31,7 @@ version = "0.2.2"
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52832"]
-version = "0.8.0-beta1"
+version = "0.8.0"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52840-hal"
-version = "0.7.0"
+version = "0.8.0-beta1"
 description = "HAL for nRF52840 microcontrollers"
 
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -33,7 +33,7 @@ version = "0.2.2"
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52840"]
-version = "0.7.0"
+version = "0.8.0-beta1"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52840-hal"
-version = "0.8.0-beta1"
+version = "0.8.0"
 description = "HAL for nRF52840 microcontrollers"
 
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -33,7 +33,7 @@ version = "0.2.2"
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52840"]
-version = "0.8.0-beta1"
+version = "0.8.0"
 
 [dependencies.embedded-hal]
 features = ["unproven"]


### PR DESCRIPTION
Note: the 810-hal beta has not yet been published due to #91.

CC @nrf-rs/nrf52 @bjc 

If there are no complaints in the next 24 hours or so, I will plan to release this as-is (after removing the `-beta1` suffix)