### PR TITLE
Only return timeout error, if receive not complete

### DIFF
--- a/nrf52-hal-common/src/uarte.rs
+++ b/nrf52-hal-common/src/uarte.rs
@@ -246,7 +246,7 @@ impl<T> Uarte<T> where T: UarteExt {
 
         let bytes_read = self.0.rxd.amount.read().bits() as usize;
 
-        if timeout_occured {
+        if timeout_occured && !event_complete {
             return Err(Error::Timeout(bytes_read));
         }
 


### PR DESCRIPTION
In the `Uarte::read_timeout` method, if the read completes at the same
time that the timeout would occur, a timeout error is thrown, even
though the read is already complete.

This commit changes this behavior, to not do that instead.