### PR TITLE
Fixed missing export

### DIFF
--- a/nrf52-hal-common/src/lib.rs
+++ b/nrf52-hal-common/src/lib.rs
@@ -83,6 +83,7 @@ impl DmaSlice {
 
 pub use crate::clocks::Clocks;
 pub use crate::delay::Delay;
+pub use crate::rng::Rng;
 pub use crate::rtc::Rtc;
 pub use crate::saadc::Saadc;
 pub use crate::spim::Spim;


### PR DESCRIPTION
The timer instance is missing, which caused errors when I tried to fix the dwm1001 crate