### PR TITLE
Update to be compatible with RTFM

### DIFF
--- a/nrf52-hal-common/src/rtc.rs
+++ b/nrf52-hal-common/src/rtc.rs
@@ -77,7 +77,7 @@ where
     }
 
     /// Enable the generation of a hardware interrupt from a given stimulus
-    pub fn enable_interrupt(&mut self, int: RtcInterrupt, nvic: &mut NVIC) {
+    pub fn enable_interrupt(&mut self, int: RtcInterrupt, nvic: Option<&mut NVIC>) {
         match int {
             RtcInterrupt::Tick => self.periph.intenset.write(|w| w.tick().set()),
             RtcInterrupt::Overflow => self.periph.intenset.write(|w| w.ovrflw().set()),
@@ -86,11 +86,13 @@ where
             RtcInterrupt::Compare2 => self.periph.intenset.write(|w| w.compare2().set()),
             RtcInterrupt::Compare3 => self.periph.intenset.write(|w| w.compare3().set()),
         }
-        nvic.enable(T::INTERRUPT);
+        if let Some(nvic) = nvic {
+            nvic.enable(T::INTERRUPT);
+        }
     }
 
     /// Disable the generation of a hardware interrupt from a given stimulus
-    pub fn disable_interrupt(&mut self, int: RtcInterrupt, nvic: &mut NVIC) {
+    pub fn disable_interrupt(&mut self, int: RtcInterrupt, nvic: Option<&mut NVIC>) {
         match int {
             RtcInterrupt::Tick => self.periph.intenclr.write(|w| w.tick().clear()),
             RtcInterrupt::Overflow => self.periph.intenclr.write(|w| w.ovrflw().clear()),
@@ -99,7 +101,9 @@ where
             RtcInterrupt::Compare2 => self.periph.intenclr.write(|w| w.compare2().clear()),
             RtcInterrupt::Compare3 => self.periph.intenclr.write(|w| w.compare3().clear()),
         }
-        nvic.disable(T::INTERRUPT);
+        if let Some(nvic) = nvic {
+            nvic.disable(T::INTERRUPT);
+        }
     }
 
     /// Enable the generation of a hardware event from a given stimulus

--- a/nrf52-hal-common/src/rtc.rs
+++ b/nrf52-hal-common/src/rtc.rs
@@ -77,6 +77,10 @@ where
     }
 
     /// Enable the generation of a hardware interrupt from a given stimulus
+    ///
+    /// If access to the NVIC is not provided, the interrupt must ALSO be enabled
+    /// there outside of this function (e.g. manually call `nvic.enable`, or through
+    /// the use of RTFM).
     pub fn enable_interrupt(&mut self, int: RtcInterrupt, nvic: Option<&mut NVIC>) {
         match int {
             RtcInterrupt::Tick => self.periph.intenset.write(|w| w.tick().set()),
@@ -92,6 +96,10 @@ where
     }
 
     /// Disable the generation of a hardware interrupt from a given stimulus
+    ///
+    /// If access to the NVIC is not provided, the interrupt must ALSO be disabled
+    /// there outside of this function (e.g. manually call `nvic.enable`, or through
+    /// the use of RTFM).
     pub fn disable_interrupt(&mut self, int: RtcInterrupt, nvic: Option<&mut NVIC>) {
         match int {
             RtcInterrupt::Tick => self.periph.intenclr.write(|w| w.tick().clear()),

--- a/nrf52-hal-common/src/rtc.rs
+++ b/nrf52-hal-common/src/rtc.rs
@@ -98,7 +98,7 @@ where
     /// Disable the generation of a hardware interrupt from a given stimulus
     ///
     /// If access to the NVIC is not provided, the interrupt must ALSO be disabled
-    /// there outside of this function (e.g. manually call `nvic.enable`, or through
+    /// there outside of this function (e.g. manually call `nvic.disable`, or through
     /// the use of RTFM).
     pub fn disable_interrupt(&mut self, int: RtcInterrupt, nvic: Option<&mut NVIC>) {
         match int {

--- a/nrf52-hal-common/src/timer.rs
+++ b/nrf52-hal-common/src/timer.rs
@@ -44,26 +44,30 @@ where
     ///
     /// Enables an interrupt that is fired when the timer reaches the value that
     /// is given as an argument to `start`.
-    pub fn enable_interrupt(&mut self, nvic: &mut NVIC) {
+    pub fn enable_interrupt(&mut self, nvic: Option<&mut NVIC>) {
         // As of this writing, the timer code only uses
         // `cc[0]`/`events_compare[0]`. If the code is extended to use other
         // compare registers, the following needs to be adapted.
         self.0.intenset.modify(|_, w| w.compare0().set());
 
-        nvic.enable(T::INTERRUPT);
+        if let Some(nvic) = nvic {
+            nvic.enable(T::INTERRUPT);
+        }
     }
 
     /// Disables the interrupt for this timer
     ///
     /// Disables an interrupt that is fired when the timer reaches the value
     /// that is given as an argument to `start`.
-    pub fn disable_interrupt(&mut self, nvic: &mut NVIC) {
+    pub fn disable_interrupt(&mut self, nvic: Option<&mut NVIC>) {
         // As of this writing, the timer code only uses
         // `cc[0]`/`events_compare[0]`. If the code is extended to use other
         // compare registers, the following needs to be adapted.
         self.0.intenclr.modify(|_, w| w.compare0().clear());
 
-        nvic.disable(T::INTERRUPT);
+        if let Some(nvic) = nvic {
+            nvic.disable(T::INTERRUPT);
+        }
     }
 
     pub fn delay(&mut self, cycles: u32) {

--- a/nrf52-hal-common/src/timer.rs
+++ b/nrf52-hal-common/src/timer.rs
@@ -44,6 +44,10 @@ where
     ///
     /// Enables an interrupt that is fired when the timer reaches the value that
     /// is given as an argument to `start`.
+    ///
+    /// If access to the NVIC is not provided, the interrupt must ALSO be enabled
+    /// there outside of this function (e.g. manually call `nvic.enable`, or through
+    /// the use of RTFM).
     pub fn enable_interrupt(&mut self, nvic: Option<&mut NVIC>) {
         // As of this writing, the timer code only uses
         // `cc[0]`/`events_compare[0]`. If the code is extended to use other
@@ -59,6 +63,10 @@ where
     ///
     /// Disables an interrupt that is fired when the timer reaches the value
     /// that is given as an argument to `start`.
+    ///
+    /// If access to the NVIC is not provided, the interrupt must ALSO be disabled
+    /// there outside of this function (e.g. manually call `nvic.enable`, or through
+    /// the use of RTFM).
     pub fn disable_interrupt(&mut self, nvic: Option<&mut NVIC>) {
         // As of this writing, the timer code only uses
         // `cc[0]`/`events_compare[0]`. If the code is extended to use other

--- a/nrf52-hal-common/src/timer.rs
+++ b/nrf52-hal-common/src/timer.rs
@@ -65,7 +65,7 @@ where
     /// that is given as an argument to `start`.
     ///
     /// If access to the NVIC is not provided, the interrupt must ALSO be disabled
-    /// there outside of this function (e.g. manually call `nvic.enable`, or through
+    /// there outside of this function (e.g. manually call `nvic.disable`, or through
     /// the use of RTFM).
     pub fn disable_interrupt(&mut self, nvic: Option<&mut NVIC>) {
         // As of this writing, the timer code only uses


### PR DESCRIPTION
Semi-reverts https://github.com/nrf-rs/nrf52-hal/pull/95.

This updates the interfaces to be compatible with RTFM. RTFM does not give the user code access to the NVIC, and enables interrupts automatically.

I suggest we maintain this pattern moving forward for peripherals that have their own interrupt enable bits.

CC @hannobraun @bjc 