### PR TITLE
Help the type checker out

### DIFF
--- a/nrf52-hal-common/src/clocks.rs
+++ b/nrf52-hal-common/src/clocks.rs
@@ -33,7 +33,7 @@ pub struct Clocks<H, L, LSTAT> {
     periph: CLOCK,
 }
 
-impl<H, L, LSTAT> Clocks<H, L, LSTAT> {
+impl Clocks<Internal, Internal, LfOscStopped> {
     pub fn new(clock: CLOCK) -> Clocks<Internal, Internal, LfOscStopped> {
         Clocks {
             hfclk: Internal,
@@ -42,6 +42,9 @@ impl<H, L, LSTAT> Clocks<H, L, LSTAT> {
             periph: clock,
         }
     }
+}
+
+impl<H, L, LSTAT> Clocks<H, L, LSTAT> {
     /// Use an external oscillator as the high frequency clock source
     pub fn enable_ext_hfosc(self) -> Clocks<ExternalOscillator, L, LSTAT> {
         self.periph.tasks_hfclkstart.write(|w| unsafe { w.bits(1) });


### PR DESCRIPTION
With the new interface, it seems that the type checker gets confused by constructors with fully generic parameters, even when the return type is certain.

Given the following code:

```rust
// Start the clocks
let _clocks: Clocks<ExternalOscillator, ExternalOscillator, LfOscStarted> = Clocks::new(device.CLOCK)
    .enable_ext_hfosc()
    .set_lfclk_src_external(LfOscConfiguration::NoExternalNoBypass)
    .start_lfclk();
```

I get the error:

```
error[E0282]: type annotations needed
   --> nodes/alarm-clock/src/main.rs:155:85
    |
155 |         let _clocks: Clocks<ExternalOscillator, ExternalOscillator, LfOscStarted> = Clocks::new(device.CLOCK)
    |                                                                                     ^^^^^^^^^^^ cannot infer type for `H`
```

This still fails with the same error even with full type ascription:

```rust
// Start the clocks
let _clocks: Clocks<Internal, Internal, LfOscStopped> = Clocks::new(device.CLOCK);
```

This change allows it to work.