### PR TITLE
Enable UARTE1 for 52840 MCUs.

### DIFF
--- a/nrf52-hal-common/src/uarte.rs
+++ b/nrf52-hal-common/src/uarte.rs
@@ -8,6 +8,9 @@ use core::ops::Deref;
 use core::sync::atomic::{compiler_fence, Ordering::SeqCst};
 use core::fmt;
 
+#[cfg(feature="52840")]
+use crate::target::UARTE1;
+
 #[cfg(feature="9160")]
 use crate::target::{
     uarte0_ns as uarte0,
@@ -393,5 +396,5 @@ pub trait Instance: Deref<Target = uarte0::RegisterBlock> {}
 
 impl Instance for UARTE0 {}
 
-#[cfg(feature="9160")]
+#[cfg(any(feature="52840", feature="9160"))]
 impl Instance for UARTE1 {}


### PR DESCRIPTION
This is mentioned in the datasheet in §4.2 Table 3 (Instantiation
Table) and exists in the PAC for this chipset.

Tested with a nrf52840-mdk board.