### PR TITLE
Fix support for SAADC on nRF9160

### DIFF
--- a/boards/actinius-icarus/src/lib.rs
+++ b/boards/actinius-icarus/src/lib.rs
@@ -47,6 +47,9 @@ pub struct Board {
     /// The SIM select line (low = nano SIM, high/default = eSIM)
     pub sim_select: Pin<Output<PushPull>>,
 
+    /// The battery voltage analog input
+    pub vbat: p0::P0_13<Input<Floating>>,
+
     /// Cortex-M33 Core peripheral: Cache and branch predictor maintenance operations
     pub CBP: pac::CBP,
 
@@ -459,6 +462,7 @@ impl Board {
             cdc_uart,
             pin_uart,
             sim_select: pins0.p0_08.into_push_pull_output(Level::High).degrade(),
+            vbat: pins0.p0_13.into_floating_input(),
             pins: Pins {
                 D0: pins0.p0_00,
                 D1: pins0.p0_01,
@@ -473,6 +477,7 @@ impl Board {
                 // Red LED is on P0_10
                 // Green LED is on P0_11
                 // Blue LED is on P0_12
+                // Battery voltage is on A0 / P0_13
                 A1: pins0.p0_14,
                 A2: pins0.p0_15,
                 A3: pins0.p0_16,


### PR DESCRIPTION
* nRF9160 has ADC0..7 on pins 13 through 20.
* The ADC returns a signed value.
* The Actinius Icarus puts battery voltage on A0 (P0_13)
* You need the fields of SaadcConfig to be public, otherwise no-one can change them...

I haven't verified whether the pin/channel mapping for non-9160 devices is correct - I just left that as-is.