### PR TITLE
Periodic timer

### DIFF
--- a/nrf52-hal-common/src/timer.rs
+++ b/nrf52-hal-common/src/timer.rs
@@ -65,7 +65,7 @@ impl<T> PeriodicTimer<T>
 where
     T: Instance,
 {
-    pub fn new_periodic(timer: T) -> PeriodicTimer<T> {
+    pub fn new(timer: T) -> PeriodicTimer<T> {
         timer
             .shorts
             .write(|w| w.compare0_clear().enabled().compare0_stop().disabled());

--- a/nrf52-hal-common/src/uarte.rs
+++ b/nrf52-hal-common/src/uarte.rs
@@ -33,7 +33,7 @@ use crate::gpio::{
     Input,
     Floating,
 };
-use crate::timer::{self, Timer, OneShotTimer};
+use crate::timer::{self, Timer};
 
 // Re-export SVD variants to allow user to directly set values
 pub use uarte0::{
@@ -236,7 +236,7 @@ impl<T> Uarte<T> where T: Instance {
     pub fn read_timeout<I>(
         &mut self,
         rx_buffer: &mut [u8],
-        timer: &mut Timer<I, OneShotTimer>,
+        timer: &mut Timer<I>,
         cycles: u32
     ) -> Result<(), Error> where I: timer::Instance
     {

--- a/nrf52-hal-common/src/uarte.rs
+++ b/nrf52-hal-common/src/uarte.rs
@@ -33,7 +33,7 @@ use crate::gpio::{
     Input,
     Floating,
 };
-use crate::timer::{self, Timer};
+use crate::timer::{self, Timer, OneShotTimer};
 
 // Re-export SVD variants to allow user to directly set values
 pub use uarte0::{
@@ -236,7 +236,7 @@ impl<T> Uarte<T> where T: Instance {
     pub fn read_timeout<I>(
         &mut self,
         rx_buffer: &mut [u8],
-        timer: &mut Timer<I>,
+        timer: &mut Timer<I, OneShotTimer>,
         cycles: u32
     ) -> Result<(), Error> where I: timer::Instance
     {


### PR DESCRIPTION
In response to #115, I have implemented 2 new types: `OneShotTimer` and `PeriodicTimer`. Additionally, backwards compatibility with `Timer` is maintained.

In order to create a new `OneShotTimer`, there are 3 options:
``` Rust
// Same as before
let timer = Timer::new(p.TIMER0);

// More explicitly
let timer = OneShotTimer::new(p.TIMER0);
// or
let timer = PeriodicTimer::new(p.TIMER0).into_oneshot();
```

In order to create a new `PeriodicTimer`, there are 2 options:
```Rust
let timer = PeriodicTimer::new(p.TIMER0);
// or
let timer = Timer::new(p.TIMER0).into_periodic();
```

Conversion between a `OneShotTimer` and a `PeriodicTimer` is facilitated by the functions `into_oneshot()` and `into_periodic()`:

``` Rust
let oneshot_timer = PeriodicTimer::new(p.TIMER0).into_oneshot();
let periodic_timer = OneShotTimer::new(p.TIMER0).into_periodic();
// This will cause an error since conversion from PeriodicTimer -> PeriodicTimer is forbidden:
let periodic_timer = PeriodicTimer::new(p.TIMER0).into_periodic();
// Similarly, conversion from OneShotTimer -> OneShotTimer is forbidden:
let oneshot_timer = OneShotTimer::new(p.TIMER0).into_oneshot();
```