### PR TITLE
Update to svd2rust 0.16-based PACs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,9 @@ debug = true
 lto = true
 opt-level = "s"
 
+
+[patch.crates-io]
+nrf52810-pac = { git = "https://github.com/JJJollyjim/nrf52810-pac.git" }
+nrf52832-pac = { git = "https://github.com/nrf-rs/nrf52832-pac.git" }
+nrf52840-pac = { git = "https://github.com/JJJollyjim/nrf52840-pac.git" }
+nrf91 = { git = "https://github.com/JJJollyjim/nrf91-rs.git" }

--- a/examples/spi-demo/Cargo.toml
+++ b/examples/spi-demo/Cargo.toml
@@ -19,7 +19,7 @@ path = "../../nrf52832-hal"
 optional = true
 
 [dependencies.nrf52832-pac]
-version = "0.8.0"
+version = "0.9.0"
 optional = true
 
 [features]

--- a/nrf52-hal-common/Cargo.toml
+++ b/nrf52-hal-common/Cargo.toml
@@ -32,19 +32,19 @@ version = "0.2.2"
 
 [dependencies.nrf52810-pac]
 optional = true
-version = "0.8.0"
+version = "0.9.0"
 
 [dependencies.nrf52832-pac]
 optional = true
-version = "0.8.0"
+version = "0.9.0"
 
 [dependencies.nrf52840-pac]
 optional = true
-version = "0.8.0"
+version = "0.9.0"
 
 [dependencies.nrf9160-pac]
 optional = true
-version = "0.1.1"
+version = "0.2.0"
 package = "nrf91"
 
 [dependencies.embedded-hal]

--- a/nrf52-hal-common/src/gpio.rs
+++ b/nrf52-hal-common/src/gpio.rs
@@ -398,14 +398,14 @@ use crate::target::p0_ns::{pin_cnf, PIN_CNF};
 use crate::target::p0::{pin_cnf, PIN_CNF};
 
 impl OpenDrainConfig {
-    fn variant(self) -> pin_cnf::DRIVEW {
+    fn variant(self) -> pin_cnf::DRIVE_A {
         use self::OpenDrainConfig::*;
 
         match self {
-            Disconnect0Standard1 => pin_cnf::DRIVEW::D0S1,
-            Disconnect0HighDrive1 => pin_cnf::DRIVEW::D0H1,
-            Standard0Disconnect1 => pin_cnf::DRIVEW::S0D1,
-            HighDrive0Disconnect1 => pin_cnf::DRIVEW::H0D1,
+            Disconnect0Standard1 => pin_cnf::DRIVE_A::D0S1,
+            Disconnect0HighDrive1 => pin_cnf::DRIVE_A::D0H1,
+            Standard0Disconnect1 => pin_cnf::DRIVE_A::S0D1,
+            HighDrive0Disconnect1 => pin_cnf::DRIVE_A::H0D1,
         }
     }
 }

--- a/nrf52-hal-common/src/saadc.rs
+++ b/nrf52-hal-common/src/saadc.rs
@@ -12,9 +12,9 @@ use core::{
 use embedded_hal::adc::{Channel, OneShot};
 
 pub use saadc::{
-    ch::config::{GAINW as Gain, REFSELW as Reference, RESPW as Resistor, TACQW as Time},
-    oversample::OVERSAMPLEW as Oversample,
-    resolution::VALW as Resolution,
+    ch::config::{GAIN_A as Gain, REFSEL_A as Reference, RESP_A as Resistor, TACQ_A as Time},
+    oversample::OVERSAMPLE_A as Oversample,
+    resolution::VAL_A as Resolution,
 };
 
 // Only 1 channel is allowed right now, a discussion needs to be had as to how

--- a/nrf52-hal-common/src/spim.rs
+++ b/nrf52-hal-common/src/spim.rs
@@ -11,7 +11,7 @@ use crate::target::{spim0_ns as spim0, SPIM0_NS as SPIM0};
 use crate::target::{spim0, SPIM0};
 
 pub use embedded_hal::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
-pub use spim0::frequency::FREQUENCYW as Frequency;
+pub use spim0::frequency::FREQUENCY_A as Frequency;
 
 use core::iter::repeat_with;
 

--- a/nrf52-hal-common/src/twim.rs
+++ b/nrf52-hal-common/src/twim.rs
@@ -22,7 +22,7 @@ use crate::{
     target_constants::EASY_DMA_SIZE,
 };
 
-pub use twim0::frequency::FREQUENCYW as Frequency;
+pub use twim0::frequency::FREQUENCY_A as Frequency;
 
 /// Interface to a TWIM instance
 ///

--- a/nrf52-hal-common/src/uarte.rs
+++ b/nrf52-hal-common/src/uarte.rs
@@ -26,7 +26,7 @@ use crate::target_constants::EASY_DMA_SIZE;
 use crate::timer::{self, Timer};
 
 // Re-export SVD variants to allow user to directly set values
-pub use uarte0::{baudrate::BAUDRATEW as Baudrate, config::PARITYW as Parity};
+pub use uarte0::{baudrate::BAUDRATE_A as Baudrate, config::PARITY_A as Parity};
 
 /// Interface to a UARTE instance
 ///

--- a/nrf52810-hal/Cargo.toml
+++ b/nrf52810-hal/Cargo.toml
@@ -18,7 +18,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 cortex-m = ">= 0.5.8, < 0.7"
 nb = "0.1.1"
-nrf52810-pac = "0.8.0"
+nrf52810-pac = "0.9.0"
 
 [dependencies.void]
 default-features = false

--- a/nrf52832-hal/Cargo.toml
+++ b/nrf52832-hal/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 [dependencies]
 cortex-m = ">= 0.5.8, < 0.7"
 nb = "0.1.1"
-nrf52832-pac = "0.8.0"
+nrf52832-pac = "0.9.0"
 
 [dependencies.void]
 default-features = false

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2018"
 [dependencies]
 cortex-m = ">= 0.5.8, < 0.7"
 nb = "0.1.1"
-nrf52840-pac = "0.8.0"
+nrf52840-pac = "0.9.0"
 
 [dependencies.void]
 default-features = false

--- a/nrf9160-hal/Cargo.toml
+++ b/nrf9160-hal/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.6"
 nb = "0.1.1"
-nrf9160-pac = { package = "nrf91", version="0.1.1" }
+nrf9160-pac = { package = "nrf91", version="0.2" }
 
 [dependencies.void]
 default-features = false


### PR DESCRIPTION
This was surprisingly easy! (assuming it actually works on hardware...)

Marking as a draft, since it includes a `patch` section in the root `Cargo.toml` to use the git versions of the PACs. That commit should be reverted once the PAC updates are released.