### PR TITLE
Re-export PAC crates as `pac`

### DIFF
--- a/boards/adafruit_nrf52pro/examples/blinky.rs
+++ b/boards/adafruit_nrf52pro/examples/blinky.rs
@@ -12,7 +12,7 @@ use adafruit_nrf52pro_bsc::hal::{
     prelude::*,
     timer::{self, Timer},
 };
-use adafruit_nrf52pro_bsc::nrf52832_pac::Peripherals;
+use adafruit_nrf52pro_bsc::pac::Peripherals;
 use adafruit_nrf52pro_bsc::Pins;
 
 #[entry]

--- a/boards/adafruit_nrf52pro/src/lib.rs
+++ b/boards/adafruit_nrf52pro/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 use crate::hal::gpio::{p0, Floating, Input};
-pub use crate::hal::nrf52832_pac;
+pub use crate::hal::pac;
 pub use nrf52832_hal as hal;
 
 /// Maps the pins to the names printed on the device

--- a/boards/nRF52-DK/src/lib.rs
+++ b/boards/nRF52-DK/src/lib.rs
@@ -15,7 +15,7 @@ pub mod prelude {
 
 use nrf52832_hal::{
     gpio::{p0, Floating, Input, Level, Output, Pin, PullUp, PushPull},
-    nrf52832_pac::{self as nrf52, CorePeripherals, Peripherals},
+    pac::{self as nrf52, CorePeripherals, Peripherals},
     uarte::{self, Baudrate as UartBaudrate, Parity as UartParity, Uarte},
 };
 

--- a/boards/nRF52840-DK/src/lib.rs
+++ b/boards/nRF52840-DK/src/lib.rs
@@ -19,7 +19,7 @@ pub mod prelude {
 
 use nrf52840_hal::{
     gpio::{p0, p1, Floating, Input, Level, Output, Pin, PullUp, PushPull},
-    nrf52840_pac::{self as nrf52, CorePeripherals, Peripherals},
+    pac::{self as nrf52, CorePeripherals, Peripherals},
     spim::{self, Frequency, Spim, MODE_0},
     uarte::{self, Baudrate as UartBaudrate, Parity as UartParity, Uarte},
 };

--- a/examples/spi-demo/src/main.rs
+++ b/examples/spi-demo/src/main.rs
@@ -23,7 +23,7 @@ use nrf52832_hal::spim::Spim;
 /// one or more Led will remain off.
 #[entry]
 fn main() -> ! {
-    let p = nrf52832_hal::nrf52832_pac::Peripherals::take().unwrap();
+    let p = nrf52832_hal::pac::Peripherals::take().unwrap();
     let port0 = p0::Parts::new(p.P0);
 
     let cs: P0_21<gpio::Output<PushPull>> = port0.p0_21.into_push_pull_output(Level::Low);

--- a/examples/twi-ssd1306/src/main.rs
+++ b/examples/twi-ssd1306/src/main.rs
@@ -13,14 +13,14 @@ use ssd1306::Builder;
 #[cfg(feature = "52832")]
 use nrf52832_hal::{
     gpio::*,
-    nrf52832_pac as pac,
+    pac,
     twim::{self, Twim},
 };
 
 #[cfg(feature = "52840")]
 use nrf52840_hal::{
     gpio::*,
-    nrf52840_pac as pac,
+    pac,
     twim::{self, Twim},
 };
 

--- a/nrf52810-hal/src/lib.rs
+++ b/nrf52810-hal/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use embedded_hal as hal;
-pub use nrf52810_pac;
+pub use nrf52810_pac as pac;
 pub use nrf52_hal_common::*;
 
 pub mod prelude {

--- a/nrf52832-hal/src/lib.rs
+++ b/nrf52832-hal/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use embedded_hal as hal;
-pub use nrf52832_pac;
+pub use nrf52832_pac as pac;
 pub use nrf52_hal_common::*;
 
 pub mod prelude {

--- a/nrf52840-hal/src/lib.rs
+++ b/nrf52840-hal/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use embedded_hal as hal;
-pub use nrf52840_pac;
+pub use nrf52840_pac as pac;
 pub use nrf52_hal_common::*;
 
 pub mod prelude {


### PR DESCRIPTION
This was already being done in the `nrf9160-hal` and it's also done like that by many (all?) of the STM32 HAL crates.

This is a breaking change.