### PR TITLE
update hals for 0.9.0 (0.2.0) release

### DIFF
--- a/boards/actinius-icarus/Cargo.toml
+++ b/boards/actinius-icarus/Cargo.toml
@@ -12,10 +12,10 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-cortex-m = "0.6.0"
-cortex-m-rt = "0.6.10"
+cortex-m = "0.6.2"
+cortex-m-rt = "0.6.11"
 panic-halt = "0.2.0"
-nrf9160-hal = { version = "0.1.0", path = "../../nrf9160-hal" }
+nrf9160-hal = { version = "0.2.0", path = "../../nrf9160-hal" }
 
 [dev-dependencies]
 nb = "0.1.1"

--- a/boards/adafruit-nrf52-bluefruit-le/Cargo.toml
+++ b/boards/adafruit-nrf52-bluefruit-le/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 nrf52832-hal = { path = "../../nrf52832-hal" }
 
 [dev-dependencies]
-cortex-m-rt = "0.6.8"
+cortex-m-rt = "0.6.12"
 panic-halt = "0.2.0"
 nb = "~0.1"
 

--- a/boards/adafruit_nrf52pro/Cargo.toml
+++ b/boards/adafruit_nrf52pro/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 nrf52832-hal = { path = "../../nrf52832-hal" }
 
 [dev-dependencies]
-cortex-m-rt = "0.6.8"
+cortex-m-rt = "0.6.12"
 cortex-m-semihosting = "~0.3"
 panic-semihosting = "~0.5"
 nb = "~0.1"

--- a/boards/nRF52-DK/Cargo.toml
+++ b/boards/nRF52-DK/Cargo.toml
@@ -10,11 +10,11 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-cortex-m = "0.6.0"
-cortex-m-rt = "0.6.7"
+cortex-m = "0.6.2"
+cortex-m-rt = "0.6.12"
 panic-halt = "0.2.0"
-nrf52832-hal = { version = "0.8.0", path = "../../nrf52832-hal" }
+nrf52832-hal = { version = "0.9.0", path = "../../nrf52832-hal" }
 
 [dev-dependencies]
-nb = "0.1.1"
-panic-semihosting = "0.5.1"
+nb = "0.1.2"
+panic-semihosting = "0.5.3"

--- a/boards/nRF52840-DK/Cargo.toml
+++ b/boards/nRF52840-DK/Cargo.toml
@@ -10,12 +10,12 @@ edition = "2018"
 
 [dependencies]
 cortex-m = { version = "0.5.4", features = [ "const-fn" ] }
-cortex-m-rt = "0.6.5"
-embedded-hal = "0.2.1"
-nrf52840-hal = { version = "0.8.0", path = "../../nrf52840-hal" }
+cortex-m-rt = "0.6.12"
+embedded-hal = "0.2.3"
+nrf52840-hal = { version = "0.9.0", path = "../../nrf52840-hal" }
 
 [dev-dependencies]
-cortex-m-rt = "0.6.5"
+cortex-m-rt = "0.6.12"
 cortex-m-semihosting = "~0.3"
 panic-semihosting = "~0.5"
 nb = "~0.1"

--- a/boards/nRF9160-DK/Cargo.toml
+++ b/boards/nRF9160-DK/Cargo.toml
@@ -12,11 +12,11 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-cortex-m = "0.6.0"
-cortex-m-rt = "0.6.7"
+cortex-m = "0.6.2"
+cortex-m-rt = "0.6.12"
 panic-halt = "0.2.0"
-nrf9160-hal = { version = "0.1.0", path = "../../nrf9160-hal" }
+nrf9160-hal = { version = "0.2.0", path = "../../nrf9160-hal" }
 
 [dev-dependencies]
-nb = "0.1.1"
-panic-semihosting = "0.5.1"
+nb = "0.1.2"
+panic-semihosting = "0.5.3"

--- a/examples/rtfm-demo/Cargo.toml
+++ b/examples/rtfm-demo/Cargo.toml
@@ -10,17 +10,17 @@ panic-semihosting = "0.5.1"
 cortex-m-semihosting = "0.3.3"
 
 [dependencies.nrf52810-hal]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../nrf52810-hal"
 optional = true
 
 [dependencies.nrf52832-hal]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../nrf52832-hal"
 optional = true
 
 [dependencies.nrf52840-hal]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../nrf52840-hal"
 optional = true
 

--- a/examples/spi-demo/Cargo.toml
+++ b/examples/spi-demo/Cargo.toml
@@ -14,7 +14,7 @@ features = ["unproven"]
 version = "0.2"
 
 [dependencies.nrf52832-hal]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../nrf52832-hal"
 optional = true
 

--- a/examples/twi-ssd1306/Cargo.toml
+++ b/examples/twi-ssd1306/Cargo.toml
@@ -8,22 +8,22 @@ authors = [
 edition = "2018"
 
 [dependencies]
-cortex-m-rt = "0.6.5"
-ssd1306 = "0.2.4"
+cortex-m-rt = "0.6.12"
+ssd1306 = "0.2.6"
 embedded-graphics = "0.4.7"
-panic-semihosting = "0.5.1"
+panic-semihosting = "0.5.3"
 
 [dependencies.embedded-hal]
 features = ["unproven"]
 version = "0.2"
 
 [dependencies.nrf52832-hal]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../nrf52832-hal"
 optional = true
 
 [dependencies.nrf52840-hal]
-version = "0.8.0"
+version = "0.9.0"
 path = "../../nrf52840-hal"
 optional = true
 

--- a/nrf52-hal-common/Cargo.toml
+++ b/nrf52-hal-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52-hal-common"
-version = "0.8.1"
+version = "0.9.0"
 description = "Common HAL for the nRF52 family of microcontrollers.  More specific HAL crates also exist."
 
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -18,9 +18,9 @@ edition = "2018"
 
 [dependencies]
 cortex-m = ">= 0.5.8, < 0.7"
-nb = "0.1.1"
+nb = "0.1.2"
 fpa = "0.1.0"
-rand_core = "0.4.0"
+rand_core = "0.5.1"
 
 [dependencies.void]
 default-features = false
@@ -28,24 +28,23 @@ version = "1.0.2"
 
 [dependencies.cast]
 default-features = false
-version = "0.2.2"
+version = "0.2.3"
 
 [dependencies.nrf52810-pac]
 optional = true
-version = "0.8.0"
+version = "0.9.0"
 
 [dependencies.nrf52832-pac]
 optional = true
-version = "0.8.0"
+version = "0.9.0"
 
 [dependencies.nrf52840-pac]
 optional = true
-version = "0.8.0"
+version = "0.9.0"
 
 [dependencies.nrf9160-pac]
 optional = true
-version = "0.1.1"
-package = "nrf91"
+version = "0.2.0"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52-hal-common/src/gpio.rs
+++ b/nrf52-hal-common/src/gpio.rs
@@ -398,14 +398,14 @@ use crate::target::p0_ns::{pin_cnf, PIN_CNF};
 use crate::target::p0::{pin_cnf, PIN_CNF};
 
 impl OpenDrainConfig {
-    fn variant(self) -> pin_cnf::DRIVEW {
+    fn variant(self) -> pin_cnf::DRIVE_A {
         use self::OpenDrainConfig::*;
 
         match self {
-            Disconnect0Standard1 => pin_cnf::DRIVEW::D0S1,
-            Disconnect0HighDrive1 => pin_cnf::DRIVEW::D0H1,
-            Standard0Disconnect1 => pin_cnf::DRIVEW::S0D1,
-            HighDrive0Disconnect1 => pin_cnf::DRIVEW::H0D1,
+            Disconnect0Standard1 => pin_cnf::DRIVE_A::D0S1,
+            Disconnect0HighDrive1 => pin_cnf::DRIVE_A::D0H1,
+            Standard0Disconnect1 => pin_cnf::DRIVE_A::S0D1,
+            HighDrive0Disconnect1 => pin_cnf::DRIVE_A::H0D1,
         }
     }
 }

--- a/nrf52-hal-common/src/saadc.rs
+++ b/nrf52-hal-common/src/saadc.rs
@@ -12,9 +12,9 @@ use core::{
 use embedded_hal::adc::{Channel, OneShot};
 
 pub use saadc::{
-    ch::config::{GAINW as Gain, REFSELW as Reference, RESPW as Resistor, TACQW as Time},
-    oversample::OVERSAMPLEW as Oversample,
-    resolution::VALW as Resolution,
+    ch::config::{GAIN_A as Gain, REFSEL_A as Reference, RESP_A as Resistor, TACQ_A as Time},
+    oversample::OVERSAMPLE_A as Oversample,
+    resolution::VAL_A as Resolution,
 };
 
 // Only 1 channel is allowed right now, a discussion needs to be had as to how

--- a/nrf52-hal-common/src/spim.rs
+++ b/nrf52-hal-common/src/spim.rs
@@ -11,7 +11,7 @@ use crate::target::{spim0_ns as spim0, SPIM0_NS as SPIM0};
 use crate::target::{spim0, SPIM0};
 
 pub use embedded_hal::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
-pub use spim0::frequency::FREQUENCYW as Frequency;
+pub use spim0::frequency::FREQUENCY_A as Frequency;
 
 use core::iter::repeat_with;
 

--- a/nrf52-hal-common/src/timer.rs
+++ b/nrf52-hal-common/src/timer.rs
@@ -2,8 +2,6 @@
 //!
 //! See product specification, chapter 24.
 
-use core::ops::Deref;
-
 #[cfg(feature = "9160")]
 use crate::target::{
     timer0_ns as timer0, Interrupt, NVIC, TIMER0_NS as TIMER0, TIMER1_NS as TIMER1,
@@ -11,15 +9,14 @@ use crate::target::{
 };
 
 #[cfg(not(feature = "9160"))]
-use crate::target::{timer0, Interrupt, NVIC, TIMER0, TIMER1, TIMER2};
+use crate::target::{Interrupt, NVIC, TIMER0, TIMER1, TIMER2};
 
 use embedded_hal::{prelude::*, timer};
 use nb::{self, block};
 use void::{unreachable, Void};
 
-// TODO: TIMER3 and TIMER4 are now timer3::RegisterBlock incompatible with timer0::RegisterBlock
-// #[cfg(any(feature = "52832", feature = "52840"))]
-// use crate::target::{timer3, TIMER3, TIMER4};
+#[cfg(any(feature = "52832", feature = "52840"))]
+use crate::target::{TIMER3, TIMER4};
 
 use core::marker::PhantomData;
 
@@ -40,13 +37,7 @@ where
     T: Instance,
 {
     pub fn one_shot(timer: T) -> Timer<T, OneShot> {
-        timer
-            .shorts
-            .write(|w| w.compare0_clear().enabled().compare0_stop().enabled());
-        timer.prescaler.write(
-            |w| unsafe { w.prescaler().bits(4) }, // 1 MHz
-        );
-        timer.bitmode.write(|w| w.bitmode()._32bit());
+        timer.set_oneshot();
 
         Timer::<T, OneShot>(timer, PhantomData)
     }
@@ -61,13 +52,7 @@ where
     T: Instance,
 {
     pub fn periodic(timer: T) -> Timer<T, Periodic> {
-        timer
-            .shorts
-            .write(|w| w.compare0_clear().enabled().compare0_stop().disabled());
-        timer.prescaler.write(
-            |w| unsafe { w.prescaler().bits(4) }, // 1 MHz
-        );
-        timer.bitmode.write(|w| w.bitmode()._32bit());
+        timer.set_periodic();
 
         Timer::<T, Periodic>(timer, PhantomData)
     }
@@ -80,17 +65,13 @@ where
     pub const TICKS_PER_SECOND: u32 = 1_000_000;
 
     pub fn into_periodic(self) -> Timer<T, Periodic> {
-        self.0
-            .shorts
-            .write(|w| w.compare0_clear().enabled().compare0_stop().disabled());
+        self.0.set_shorts_periodic();
 
         Timer::<T, Periodic>(self.free(), PhantomData)
     }
 
     pub fn into_oneshot(self) -> Timer<T, OneShot> {
-        self.0
-            .shorts
-            .write(|w| w.compare0_clear().enabled().compare0_stop().enabled());
+        self.0.set_shorts_oneshot();
 
         Timer::<T, OneShot>(self.free(), PhantomData)
     }
@@ -102,8 +83,7 @@ where
 
     /// Return the current value of the counter, by capturing to CC[1].
     pub fn read(&self) -> u32 {
-        self.0.tasks_capture[1].write(|w| unsafe { w.bits(1) });
-        self.0.cc[1].read().bits()
+        self.0.read_counter()
     }
 
     /// Enables the interrupt for this timer
@@ -118,7 +98,7 @@ where
         // As of this writing, the timer code only uses
         // `cc[0]`/`events_compare[0]`. If the code is extended to use other
         // compare registers, the following needs to be adapted.
-        self.0.intenset.modify(|_, w| w.compare0().set());
+        self.0.enable_interrupt();
 
         if let Some(_nvic) = nvic {
             unsafe { NVIC::unmask(T::INTERRUPT) };
@@ -137,7 +117,7 @@ where
         // As of this writing, the timer code only uses
         // `cc[0]`/`events_compare[0]`. If the code is extended to use other
         // compare registers, the following needs to be adapted.
-        self.0.intenclr.modify(|_, w| w.compare0().clear());
+        self.0.disable_interrupt();
 
         if let Some(_nvic) = nvic {
             NVIC::mask(T::INTERRUPT);
@@ -167,30 +147,7 @@ where
     where
         Time: Into<Self::Time>,
     {
-        // If the following sequence of events occurs, the COMPARE event will be
-        // set here:
-        // 1. `start` is called.
-        // 2. The timer runs out but `wait` is _not_ called.
-        // 3. `start` is called again
-        //
-        // If that happens, then we need to reset the event here explicitly, as
-        // nothing else this method does will reset the event, and if it's still
-        // active after this method exits, then the next call to `wait` will
-        // return immediately, no matter how much time has actually passed.
-        self.0.events_compare[0].reset();
-
-        // Configure timer to trigger EVENTS_COMPARE when given number of cycles
-        // is reached.
-        self.0.cc[0].write(|w|
-            // The timer mode was set to 32 bits above, so all possible values
-            // of `cycles` are valid.
-            unsafe { w.cc().bits(cycles.into()) });
-
-        // Clear the counter value
-        self.0.tasks_clear.write(|w| unsafe { w.bits(1) });
-
-        // Start the timer
-        self.0.tasks_start.write(|w| unsafe { w.bits(1) });
+        self.0.timer_start(cycles);
     }
 
     /// Wait for the timer to stop
@@ -202,13 +159,13 @@ where
     /// To block until the timer has stopped, use the `block!` macro from the
     /// `nb` crate. Please refer to the documentation of `nb` for other options.
     fn wait(&mut self) -> nb::Result<(), Void> {
-        if self.0.events_compare[0].read().bits() == 0 {
+        if self.0.timer_running() {
             // EVENTS_COMPARE has not been triggered yet
             return Err(nb::Error::WouldBlock);
         }
 
         // Reset the event, otherwise it will always read `1` from now on.
-        self.0.events_compare[0].write(|w| w);
+        self.0.timer_reset_event();
 
         Ok(())
     }
@@ -222,8 +179,7 @@ where
 
     // Cancel a running timer.
     fn cancel(&mut self) -> Result<(), Self::Error> {
-        self.0.tasks_stop.write(|w| unsafe { w.bits(1) });
-        self.0.events_compare[0].write(|w| w);
+        self.0.timer_cancel();
         Ok(())
     }
 }
@@ -231,9 +187,32 @@ where
 impl<T> timer::Periodic for Timer<T, Periodic> where T: Instance {}
 
 /// Implemented by all `timer0::TIMER` instances
-pub trait Instance: Deref<Target = timer0::RegisterBlock> {
+pub trait Instance {
     /// This interrupt associated with this RTC instance
     const INTERRUPT: Interrupt;
+
+    fn timer_start<Time>(&self, cycles: Time)
+    where Time: Into<u32>;
+
+    fn timer_reset_event(&self);
+
+    fn timer_cancel(&self);
+
+    fn timer_running(&self) -> bool;
+
+    fn read_counter(&self) -> u32;
+
+    fn disable_interrupt(&self);
+
+    fn enable_interrupt(&self);
+
+    fn set_shorts_periodic(&self);
+
+    fn set_shorts_oneshot(&self);
+
+    fn set_periodic(&self);
+
+    fn set_oneshot(&self);
 }
 
 macro_rules! impl_instance {
@@ -241,6 +220,90 @@ macro_rules! impl_instance {
         $(
             impl Instance for $name {
                 const INTERRUPT: Interrupt = Interrupt::$name;
+
+                fn timer_start<Time>(&self, cycles: Time)
+                where
+                    Time: Into<u32>,
+                {
+                    // If the following sequence of events occurs, the COMPARE event will be
+                    // set here:
+                    // 1. `start` is called.
+                    // 2. The timer runs out but `wait` is _not_ called.
+                    // 3. `start` is called again
+                    //
+                    // If that happens, then we need to reset the event here explicitly, as
+                    // nothing else this method does will reset the event, and if it's still
+                    // active after this method exits, then the next call to `wait` will
+                    // return immediately, no matter how much time has actually passed.
+                    self.events_compare[0].reset();
+            
+                    // Configure timer to trigger EVENTS_COMPARE when given number of cycles
+                    // is reached.
+                    self.cc[0].write(|w|
+                        // The timer mode was set to 32 bits above, so all possible values
+                        // of `cycles` are valid.
+                        unsafe { w.cc().bits(cycles.into()) });
+            
+                    // Clear the counter value
+                    self.tasks_clear.write(|w| unsafe { w.bits(1) });
+            
+                    // Start the timer
+                    self.tasks_start.write(|w| unsafe { w.bits(1) });
+                }
+            
+                fn timer_reset_event(&self) {
+                    self.events_compare[0].write(|w| w);
+                }
+            
+                fn timer_cancel(&self) {
+                    self.tasks_stop.write(|w| unsafe { w.bits(1) });
+                    self.timer_reset_event();
+                }
+            
+                fn timer_running(&self) -> bool {
+                    self.events_compare[0].read().bits() == 0
+                }
+            
+                fn read_counter(&self) -> u32 {
+                    self.tasks_capture[1].write(|w| unsafe { w.bits(1) });
+                    self.cc[1].read().bits()
+                }
+            
+                fn disable_interrupt(&self) {
+                    self.intenclr.modify(|_, w| w.compare0().clear());
+                }
+            
+                fn enable_interrupt(&self) {
+                    self.intenset.modify(|_, w| w.compare0().set());
+                }
+            
+                fn set_shorts_periodic(&self) {
+                    self
+                    .shorts
+                    .write(|w| w.compare0_clear().enabled().compare0_stop().disabled());
+                }
+            
+                fn set_shorts_oneshot(&self) {
+                    self
+                    .shorts
+                    .write(|w| w.compare0_clear().enabled().compare0_stop().enabled());
+                }
+
+                fn set_periodic(&self) {
+                    self.set_shorts_periodic();
+                    self.prescaler.write(
+                        |w| unsafe { w.prescaler().bits(4) }, // 1 MHz
+                    );
+                    self.bitmode.write(|w| w.bitmode()._32bit());
+                }
+
+                fn set_oneshot(&self) {
+                    self.set_shorts_oneshot();
+                    self.prescaler.write(
+                        |w| unsafe { w.prescaler().bits(4) }, // 1 MHz
+                    );
+                    self.bitmode.write(|w| w.bitmode()._32bit());
+                }
             }
         )*
     }
@@ -248,6 +311,5 @@ macro_rules! impl_instance {
 
 impl_instance!(TIMER0, TIMER1, TIMER2,);
 
-// TODO: TIMER3 and TIMER4 are now timer3::RegisterBlock incompatible with timer0::RegisterBlock
-// #[cfg(any(feature = "52832", feature = "52840"))]
-// impl_instance!(TIMER3, TIMER4,);
+#[cfg(any(feature = "52832", feature = "52840"))]
+impl_instance!(TIMER3, TIMER4,);

--- a/nrf52-hal-common/src/timer.rs
+++ b/nrf52-hal-common/src/timer.rs
@@ -17,8 +17,9 @@ use embedded_hal::{prelude::*, timer};
 use nb::{self, block};
 use void::{unreachable, Void};
 
-#[cfg(any(feature = "52832", feature = "52840"))]
-use crate::target::{TIMER3, TIMER4};
+// TODO: TIMER3 and TIMER4 are now timer3::RegisterBlock incompatible with timer0::RegisterBlock
+// #[cfg(any(feature = "52832", feature = "52840"))]
+// use crate::target::{timer3, TIMER3, TIMER4};
 
 use core::marker::PhantomData;
 
@@ -229,7 +230,7 @@ where
 
 impl<T> timer::Periodic for Timer<T, Periodic> where T: Instance {}
 
-/// Implemented by all `TIMER` instances
+/// Implemented by all `timer0::TIMER` instances
 pub trait Instance: Deref<Target = timer0::RegisterBlock> {
     /// This interrupt associated with this RTC instance
     const INTERRUPT: Interrupt;
@@ -247,5 +248,6 @@ macro_rules! impl_instance {
 
 impl_instance!(TIMER0, TIMER1, TIMER2,);
 
-#[cfg(any(feature = "52832", feature = "52840"))]
-impl_instance!(TIMER3, TIMER4,);
+// TODO: TIMER3 and TIMER4 are now timer3::RegisterBlock incompatible with timer0::RegisterBlock
+// #[cfg(any(feature = "52832", feature = "52840"))]
+// impl_instance!(TIMER3, TIMER4,);

--- a/nrf52-hal-common/src/timer.rs
+++ b/nrf52-hal-common/src/timer.rs
@@ -4,8 +4,7 @@
 
 #[cfg(feature = "9160")]
 use crate::target::{
-    timer0_ns as timer0, Interrupt, NVIC, TIMER0_NS as TIMER0, TIMER1_NS as TIMER1,
-    TIMER2_NS as TIMER2,
+    Interrupt, NVIC, TIMER0_NS as TIMER0, TIMER1_NS as TIMER1, TIMER2_NS as TIMER2,
 };
 
 #[cfg(not(feature = "9160"))]

--- a/nrf52-hal-common/src/timer.rs
+++ b/nrf52-hal-common/src/timer.rs
@@ -192,7 +192,8 @@ pub trait Instance {
     const INTERRUPT: Interrupt;
 
     fn timer_start<Time>(&self, cycles: Time)
-    where Time: Into<u32>;
+    where
+        Time: Into<u32>;
 
     fn timer_reset_event(&self);
 
@@ -236,53 +237,53 @@ macro_rules! impl_instance {
                     // active after this method exits, then the next call to `wait` will
                     // return immediately, no matter how much time has actually passed.
                     self.events_compare[0].reset();
-            
+
                     // Configure timer to trigger EVENTS_COMPARE when given number of cycles
                     // is reached.
                     self.cc[0].write(|w|
                         // The timer mode was set to 32 bits above, so all possible values
                         // of `cycles` are valid.
                         unsafe { w.cc().bits(cycles.into()) });
-            
+
                     // Clear the counter value
                     self.tasks_clear.write(|w| unsafe { w.bits(1) });
-            
+
                     // Start the timer
                     self.tasks_start.write(|w| unsafe { w.bits(1) });
                 }
-            
+
                 fn timer_reset_event(&self) {
                     self.events_compare[0].write(|w| w);
                 }
-            
+
                 fn timer_cancel(&self) {
                     self.tasks_stop.write(|w| unsafe { w.bits(1) });
                     self.timer_reset_event();
                 }
-            
+
                 fn timer_running(&self) -> bool {
                     self.events_compare[0].read().bits() == 0
                 }
-            
+
                 fn read_counter(&self) -> u32 {
                     self.tasks_capture[1].write(|w| unsafe { w.bits(1) });
                     self.cc[1].read().bits()
                 }
-            
+
                 fn disable_interrupt(&self) {
                     self.intenclr.modify(|_, w| w.compare0().clear());
                 }
-            
+
                 fn enable_interrupt(&self) {
                     self.intenset.modify(|_, w| w.compare0().set());
                 }
-            
+
                 fn set_shorts_periodic(&self) {
                     self
                     .shorts
                     .write(|w| w.compare0_clear().enabled().compare0_stop().disabled());
                 }
-            
+
                 fn set_shorts_oneshot(&self) {
                     self
                     .shorts

--- a/nrf52-hal-common/src/twim.rs
+++ b/nrf52-hal-common/src/twim.rs
@@ -22,7 +22,7 @@ use crate::{
     target_constants::EASY_DMA_SIZE,
 };
 
-pub use twim0::frequency::FREQUENCYW as Frequency;
+pub use twim0::frequency::FREQUENCY_A as Frequency;
 
 /// Interface to a TWIM instance
 ///

--- a/nrf52-hal-common/src/uarte.rs
+++ b/nrf52-hal-common/src/uarte.rs
@@ -26,7 +26,7 @@ use crate::target_constants::EASY_DMA_SIZE;
 use crate::timer::{self, Timer};
 
 // Re-export SVD variants to allow user to directly set values
-pub use uarte0::{baudrate::BAUDRATEW as Baudrate, config::PARITYW as Parity};
+pub use uarte0::{baudrate::BAUDRATE_A as Baudrate, config::PARITY_A as Parity};
 
 /// Interface to a UARTE instance
 ///

--- a/nrf52810-hal/Cargo.toml
+++ b/nrf52810-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52810-hal"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2018"
 description = "HAL for nRF52810 microcontrollers"
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -17,8 +17,8 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 cortex-m = ">= 0.5.8, < 0.7"
-nb = "0.1.1"
-nrf52810-pac = "0.8.0"
+nb = "0.1.2"
+nrf52810-pac = "0.9.0"
 
 [dependencies.void]
 default-features = false
@@ -26,17 +26,17 @@ version = "1.0.2"
 
 [dependencies.cast]
 default-features = false
-version = "0.2.2"
+version = "0.2.3"
 
 [dependencies.nrf52-hal-common]
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52810"]
-version = "0.8.0"
+version = "0.9.0"
 
 [dependencies.embedded-hal]
 features = ["unproven"]
-version = "0.2.1"
+version = "0.2.3"
 
 [features]
 doc = []

--- a/nrf52832-hal/Cargo.toml
+++ b/nrf52832-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52832-hal"
-version = "0.8.1"
+version = "0.9.0"
 description = "HAL for nRF52832 microcontrollers"
 
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -17,7 +17,7 @@ edition = "2018"
 [dependencies]
 cortex-m = ">= 0.5.8, < 0.7"
 nb = "0.1.1"
-nrf52832-pac = "0.8.0"
+nrf52832-pac = "0.9.0"
 
 [dependencies.void]
 default-features = false
@@ -25,17 +25,17 @@ version = "1.0.2"
 
 [dependencies.cast]
 default-features = false
-version = "0.2.2"
+version = "0.2.3"
 
 [dependencies.nrf52-hal-common]
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52832"]
-version = "0.8.0"
+version = "0.9.0"
 
 [dependencies.embedded-hal]
 features = ["unproven"]
-version = "0.2.1"
+version = "0.2.3"
 
 [features]
 doc = []

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52840-hal"
-version = "0.8.1"
+version = "0.9.0"
 description = "HAL for nRF52840 microcontrollers"
 
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -18,8 +18,8 @@ edition = "2018"
 
 [dependencies]
 cortex-m = ">= 0.5.8, < 0.7"
-nb = "0.1.1"
-nrf52840-pac = "0.8.0"
+nb = "0.1.2"
+nrf52840-pac = "0.9.0"
 
 [dependencies.void]
 default-features = false
@@ -27,17 +27,17 @@ version = "1.0.2"
 
 [dependencies.cast]
 default-features = false
-version = "0.2.2"
+version = "0.2.3"
 
 [dependencies.nrf52-hal-common]
 path = "../nrf52-hal-common"
 default-features = false
 features = ["52840"]
-version = "0.8.0"
+version = "0.9.0"
 
 [dependencies.embedded-hal]
 features = ["unproven"]
-version = "0.2.1"
+version = "0.2.3"
 
 [features]
 doc = []

--- a/nrf9160-hal/Cargo.toml
+++ b/nrf9160-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf9160-hal"
-version = "0.1.0"
+version = "0.2.0"
 description = "HAL for nRF9160 system-in-package"
 
 repository = "https://github.com/nrf-rs/nrf52-hal"
@@ -15,8 +15,8 @@ edition = "2018"
 
 [dependencies]
 cortex-m = "0.6"
-nb = "0.1.1"
-nrf9160-pac = { package = "nrf91", version="0.1.1" }
+nb = "0.1.2"
+nrf9160-pac = "0.2.0"
 
 [dependencies.void]
 default-features = false
@@ -24,17 +24,17 @@ version = "1.0.2"
 
 [dependencies.cast]
 default-features = false
-version = "0.2.2"
+version = "0.2.3"
 
 [dependencies.nrf52-hal-common]
 path = "../nrf52-hal-common"
 default-features = false
 features = ["9160"]
-version = "0.8.0"
+version = "0.9.0"
 
 [dependencies.embedded-hal]
 features = ["unproven"]
-version = "0.2.1"
+version = "0.2.3"
 
 [features]
 doc = []


### PR DESCRIPTION
Bump PAC and minor dependencies and fix code for 0.9 release.

NOTE: `TIMER3` and `TIMER4` of the `nrf528*` MCUs now have separate `RegisterBlock` types and cannot be unified. I just commented them out for now, a better solution is welcome.