### PR TITLE
add customer UICR registers abstraction

### DIFF
--- a/nrf52-hal-common/src/lib.rs
+++ b/nrf52-hal-common/src/lib.rs
@@ -29,6 +29,9 @@ pub mod timer;
 pub mod twim;
 pub mod uarte;
 
+#[cfg(not(feature = "9160"))]
+pub mod uicr;
+
 pub mod prelude {
     pub use crate::hal::digital::v2::*;
     pub use crate::hal::prelude::*;

--- a/nrf52-hal-common/src/uicr.rs
+++ b/nrf52-hal-common/src/uicr.rs
@@ -13,8 +13,14 @@ impl<T> Uicr<T>
 where
     T: Instance,
 {
+    /// Construct a new `Uicr` from `pac::UICR`
     pub fn new(uicr: T) -> Self {
         Self(uicr)
+    }
+
+    /// Release the `pac::UICR` instance back
+    pub fn free(self) -> T {
+        self.0
     }
 
     /// Erase the UICR registers. UICR registers can only be set to `0` bits, additional

--- a/nrf52-hal-common/src/uicr.rs
+++ b/nrf52-hal-common/src/uicr.rs
@@ -31,6 +31,8 @@ impl Uicr {
 
     /// Store a slice of `&[u32]` values to the customer registers with given offset
     /// - offset + slice length must be less than 32
+    /// - initial value after erase is 0xFFFF_FFFFu32
+    /// - UICR registers can only be set to `0` bits, additional overrides back to `1` can only be performed by erasing the UICR registers
     pub fn store_customer(&mut self, nvmc: &mut NVMC, offset: usize, values: &[u32]) {
         assert!(values.len() + offset <= self.0.customer.len()); // ensure we fit
         assert!(nvmc.config.read().wen().is_een() == false); // write + erase is forbidden!

--- a/nrf52-hal-common/src/uicr.rs
+++ b/nrf52-hal-common/src/uicr.rs
@@ -20,7 +20,7 @@ impl Uicr {
 
     /// Erase the UICR registers. UICR registers can only be set to `0` bits, additional
     /// overrides back to `1` can only be performed by erasing the UICR registers.
-    /// - Sets all registers to 0xFFFFu32
+    /// - Sets all registers to 0xFFFF_FFFFu32
     pub fn erase(&mut self, nvmc: &mut NVMC) {
         assert!(nvmc.config.read().wen().is_wen() == false); // write + erase is forbidden!
 

--- a/nrf52-hal-common/src/uicr.rs
+++ b/nrf52-hal-common/src/uicr.rs
@@ -48,6 +48,8 @@ impl Uicr {
     /// - offset + slice length must be less than 32
     /// - returns the loaded slice
     pub fn load_customer<'a>(&mut self, offset: usize, values: &'a mut [u32]) -> &'a [u32] {
+        assert!(values.len() + offset <= self.0.customer.len()); // ensure we fit
+
         let range = offset..offset + values.len();
         for (i, reg_i) in range.enumerate() {
             values[i] = self.0.customer[reg_i].read().customer().bits()

--- a/nrf52-hal-common/src/uicr.rs
+++ b/nrf52-hal-common/src/uicr.rs
@@ -1,3 +1,10 @@
+//! HAL interface to the UICR core component
+//!
+//! See product specification:
+//!
+//! - nrf52810: Section 4.5
+//! - nrf52832: Section 14
+//! - nrf52840: Section 4.5
 use crate::target::{NVMC, UICR};
 
 /// Interface to a UICR instance

--- a/nrf52-hal-common/src/uicr.rs
+++ b/nrf52-hal-common/src/uicr.rs
@@ -1,25 +1,20 @@
-use crate::target::{uicr, NVMC, UICR};
-
-use core::ops::Deref;
+use crate::target::{NVMC, UICR};
 
 /// Interface to a UICR instance
 ///
 /// This is a very basic interface that comes with the following limitations:
 /// - Only `customer` registers are usable for storing and loading of data
 /// - Erase must be performed in order to write bits with value `1` over `0`
-pub struct Uicr<T>(T);
+pub struct Uicr(UICR);
 
-impl<T> Uicr<T>
-where
-    T: Instance,
-{
+impl Uicr {
     /// Construct a new `Uicr` from `pac::UICR`
-    pub fn new(uicr: T) -> Self {
+    pub fn new(uicr: UICR) -> Self {
         Self(uicr)
     }
 
     /// Release the `pac::UICR` instance back
-    pub fn free(self) -> T {
+    pub fn free(self) -> UICR {
         self.0
     }
 
@@ -59,7 +54,3 @@ where
         values
     }
 }
-
-pub trait Instance: Deref<Target = uicr::RegisterBlock> {}
-
-impl Instance for UICR {}

--- a/nrf52-hal-common/src/uicr.rs
+++ b/nrf52-hal-common/src/uicr.rs
@@ -1,0 +1,46 @@
+use crate::target::{uicr, NVMC, UICR};
+
+use core::ops::Deref;
+
+pub struct Uicr<T>(T);
+
+impl<T> Uicr<T>
+where
+    T: Instance,
+{
+    pub fn new(uicr: T) -> Self {
+        Self(uicr)
+    }
+
+    pub fn erase(&mut self, nvmc: &mut NVMC) {
+        assert!(nvmc.config.read().wen().is_wen() == false); // write + erase is forbidden!
+
+        nvmc.config.write(|w| w.wen().een());
+        nvmc.eraseuicr.write(|w| w.eraseuicr().erase());
+        nvmc.config.reset()
+    }
+
+    pub fn store_customer(&mut self, nvmc: &mut NVMC, offset: usize, values: &[u32]) {
+        assert!(values.len() + offset <= self.0.customer.len()); // ensure we fit
+        assert!(nvmc.config.read().wen().is_een() == false); // write + erase is forbidden!
+
+        nvmc.config.write(|w| w.wen().wen());
+        for (i, value) in values.iter().enumerate() {
+            self.0.customer[offset + i].write(|w| unsafe { w.customer().bits(*value) });
+        }
+        nvmc.config.reset()
+    }
+
+    pub fn load_customer<'a>(&mut self, offset: usize, values: &'a mut [u32]) -> &'a [u32] {
+        let range = offset..offset + values.len();
+        for (i, reg_i) in range.enumerate() {
+            values[i] = self.0.customer[reg_i].read().customer().bits()
+        }
+
+        values
+    }
+}
+
+pub trait Instance: Deref<Target = uicr::RegisterBlock> {}
+
+impl Instance for UICR {}


### PR DESCRIPTION
Adds a basic erase/store/load UICR abstraction for accessing the 32 `customer` registers on `nrf528**` MCUs.